### PR TITLE
feat(token): more API token checks

### DIFF
--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/SmartsheetBuilder.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/SmartsheetBuilder.cs
@@ -103,6 +103,13 @@ namespace Smartsheet.Api
         public const string GOV_BASE_URI = "https://api.smartsheetgov.com/2.0/";
 
         /// <summary>
+        /// <para>Represents the environment variable for locating the Smartsheet API access token.</para>
+        /// 
+        /// <para>It is a constant with Value "SMARTSHEET_ACCESS_TOKEN".</para>
+        /// </summary>
+        public const string SMARTSHEET_ACCESS_TOKEN = "SMARTSHEET_ACCESS_TOKEN";
+
+        /// <summary>
         /// Constructor.
         /// </summary>
         public SmartsheetBuilder()
@@ -265,7 +272,9 @@ namespace Smartsheet.Api
 
             if (accessToken == null)
             {
-                accessToken = Environment.GetEnvironmentVariable("SMARTSHEET_ACCESS_TOKEN");
+                accessToken = Environment.GetEnvironmentVariable(SMARTSHEET_ACCESS_TOKEN, EnvironmentVariableTarget.Process) ??
+                    Environment.GetEnvironmentVariable(SMARTSHEET_ACCESS_TOKEN, EnvironmentVariableTarget.User) ??
+                    Environment.GetEnvironmentVariable(SMARTSHEET_ACCESS_TOKEN, EnvironmentVariableTarget.Machine);
             }
 
             SmartsheetImpl smartsheet = new SmartsheetImpl(baseURI, accessToken, httpClient, jsonSerializer, dateTimeFixOptOut);


### PR DESCRIPTION
A Smartsheet API token can be passed via environment variables, to the Smartsheet SDK. However, there are multiple levels of scope for an environment variable supported within the .Net runtime – see [documentation](https://learn.microsoft.com/en-us/dotnet/api/system.environmentvariabletarget) for more details.

The following scopes are possible:
- process
- user
- machine

This PR augments the current SDK code to check for the presence of a user defined environment variable, if no process defined one is found; thereafter, checking for the presence of a machine defined environment variable, if no user defined one is found.

There is no backwards incompatibility introduced by this PR.

