### PR TITLE
fix(api/models): property name to match api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.0.1] - 2023-07-21
+### Fixed
+- `AutomationAction` object property updated to match Smartsheet API
+
 ## [3.0.0] - 2022-12-07
 ### Updated
 - Migrated SDK to new project

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/AutomationAction.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/AutomationAction.cs
@@ -43,7 +43,7 @@ namespace Smartsheet.Api.Models
         /// <summary>
         /// Specifies which columns to include in message
         /// </summary>
-        private IList<long> includeColumnIds;
+        private IList<long> includedColumnIds;
 
         /// <summary>
         /// Include discussions in email
@@ -114,10 +114,10 @@ namespace Smartsheet.Api.Models
         /// Gets the list of included columns
         /// </summary>
         /// <returns> the list of included columns </returns>
-        public IList<long> IncludeColumnIds
+        public IList<long> IncludedColumnIds
         {
-            get { return includeColumnIds; }
-            set { includeColumnIds = value; }
+            get { return includedColumnIds; }
+            set { includedColumnIds = value; }
         }
 
         /// <summary>


### PR DESCRIPTION
There was a mismatch in the property names between the model within the SDK and the Smartsheet API. 

This is the Smartsheet API object definition: https://smartsheet.redoc.ly/tag/automationRulesObjects#section/AutomationAction-Object

