### PR TITLE
fix: attachment content

### DIFF
--- a/integration-test-sdk-net60/AttachmentResourcesTest.cs
+++ b/integration-test-sdk-net60/AttachmentResourcesTest.cs
@@ -1,4 +1,5 @@
-﻿using Smartsheet.Api;
+﻿using RestSharp;
+using Smartsheet.Api;
 using Smartsheet.Api.Models;
 
 namespace integration_test_sdk_net60
@@ -117,6 +118,16 @@ namespace integration_test_sdk_net60
             Attachment attachment = smartsheet.SheetResources.CommentResources.AttachmentResources.AttachFile(sheetId, commentId, path, "text/plain");
             Assert.IsTrue(attachment.AttachmentType == AttachmentType.FILE);
             Assert.IsTrue(attachment.Name == "TestFile.txt");
+
+            attachment = smartsheet.SheetResources.AttachmentResources.GetAttachment(sheetId, attachment.Id.Value);
+
+            var request = new RestRequest(attachment.Url);
+
+            var attachmentContent = new RestClient(attachment.Url).Get(request).Content;
+
+            var fileContents = File.ReadAllText(path);
+
+            Assert.AreEqual(attachmentContent, fileContents);
 
             Attachment attachToResource = new Attachment.CreateAttachmentBuilder("http://www.google.com", AttachmentType.LINK).Build();
             attachment = smartsheet.SheetResources.CommentResources.AttachmentResources.AttachUrl(sheetId, commentId, attachToResource);

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Http/DefaultHttpClient.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Http/DefaultHttpClient.cs
@@ -275,9 +275,10 @@ namespace Smartsheet.Api.Internal.Http
                         // JsonParameter param = new JsonParameter();
                         // restRequest = restRequest.AddBody(param);
                     } else {
-  
-                        BodyParameter param = new BodyParameter(smartsheetRequest.Entity.ContentType, Util.ReadAllBytes(smartsheetRequest.Entity.GetBinaryContent()), smartsheetRequest.Entity.ContentType);
-                        restRequest = restRequest.AddBody(param);
+                        var bytes = Util.ReadAllBytes(smartsheetRequest.Entity.GetBinaryContent());
+                        var contentType = smartsheetRequest.Entity.ContentType;
+
+                        restRequest = restRequest.AddBody(bytes, contentType);
                     }
 
                 }


### PR DESCRIPTION
## Description

in resolution of #51 the request body for attachments was wrapped in a second param container causing the attachment to be a serialized representation of the attachment metadata instead of the attachment data itself