### PR TITLE
Clean up nulls in unit tests. Reduce the 300 "Nullable value type may be null" warnings

### DIFF
--- a/integration-test-sdk-net80/AttachmentResourcesTest.cs
+++ b/integration-test-sdk-net80/AttachmentResourcesTest.cs
@@ -110,7 +110,7 @@ namespace integration_test_sdk_net80
             Assert.IsTrue(attachment.Name == "TestFile.txt");
 
             VerifyAttachmentContent(smartsheet, sheetId, attachment);
-
+            Assert.IsNotNull(attachment.Id);
             return attachment.Id.Value;
         }
 
@@ -119,7 +119,9 @@ namespace integration_test_sdk_net80
             Row[] rows = new Row[] { new Row.AddRowBuilder(true, null, null, null, null).Build() };
             smartsheet.SheetResources.RowResources.AddRows(sheetId, rows);
             Sheet sheet = smartsheet.SheetResources.GetSheet(sheetId);
-            long rowId = sheet.Rows[0].Id.Value;
+            var sheetRows = sheet.Rows[0].Id;
+            Assert.IsNotNull(sheetRows);
+            long rowId = sheetRows.Value;
             Attachment attachment = smartsheet.SheetResources.RowResources.AttachmentResources.AttachFile(sheetId, rowId, path);
             Assert.IsTrue(attachment.AttachmentType == AttachmentType.FILE);
             Assert.IsTrue(attachment.Name == "TestFile.txt");
@@ -137,7 +139,9 @@ namespace integration_test_sdk_net80
         {
             Discussion discussionToCreate = new Discussion.CreateDiscussionBuilder("A Disc", new Comment.AddCommentBuilder("A comm").Build()).Build();
             Discussion discussionCreated = smartsheet.SheetResources.DiscussionResources.CreateDiscussion(sheetId, discussionToCreate);
-            long commentId = discussionCreated.Comments[0].Id.Value;
+            var comment = discussionCreated.Comments[0].Id;
+            Assert.IsNotNull(comment);
+            long commentId = comment.Value;
             Attachment attachment = smartsheet.SheetResources.CommentResources.AttachmentResources.AttachFile(sheetId, commentId, path, "text/plain");
             Assert.IsTrue(attachment.AttachmentType == AttachmentType.FILE);
             Assert.IsTrue(attachment.Name == "TestFile.txt");
@@ -148,6 +152,7 @@ namespace integration_test_sdk_net80
             attachment = smartsheet.SheetResources.CommentResources.AttachmentResources.AttachUrl(sheetId, commentId, attachToResource);
             Assert.IsTrue(attachment.Url == "http://www.google.com");
 
+            Assert.IsNotNull(discussionCreated.Id);
             return discussionCreated.Id.Value;
         }
 
@@ -161,11 +166,13 @@ namespace integration_test_sdk_net80
             Sheet createdSheet = smartsheet.SheetResources.CreateSheet(new Sheet.CreateSheetBuilder("new sheet", columnsToCreate).Build());
             Assert.IsTrue(createdSheet.Columns.Count == 3);
             Assert.IsTrue(createdSheet.Columns[1].Title == "col 2");
+            Assert.IsNotNull(createdSheet.Id);
             return createdSheet.Id.Value;
         }
 
         private void VerifyAttachmentContent(SmartsheetClient smartsheet, long sheetId, Attachment attachment)
         {
+            Assert.IsNotNull(attachment.Id);
             attachment = smartsheet.SheetResources.AttachmentResources.GetAttachment(sheetId, attachment.Id.Value);
 
             var request = new RestRequest(attachment.Url);

--- a/integration-test-sdk-net80/CellResourcesTest.cs
+++ b/integration-test-sdk-net80/CellResourcesTest.cs
@@ -14,7 +14,9 @@ namespace integration_test_sdk_net80
             long sheetId = CreateSheet(smartsheet);
 
             PaginatedResult<Column> columnsResult = smartsheet.SheetResources.ColumnResources.ListColumns(sheetId);
-            long columnId = columnsResult.Data[0].Id.Value;
+            var columnsResultFirst = columnsResult.Data[0].Id;
+            Assert.IsNotNull(columnsResultFirst);
+            long columnId = columnsResultFirst.Value;
 
             Cell[] cellsToAdd = new Cell[] { new Cell.AddCellBuilder(columnId, true).SetValue("hello").SetStrict(false).Build() };
 
@@ -33,7 +35,10 @@ namespace integration_test_sdk_net80
             Row row = new Row.AddRowBuilder(true, null, null, null, null).SetCells(cellsToAdd).Build();
             IList<Row> rows = smartsheet.SheetResources.RowResources.AddRows(sheetId, new Row[] { row });
             Assert.IsTrue(rows.Count == 1);
-            long rowId = rows[0].Id.Value;
+
+            var rowsId = rows[0].Id;
+            Assert.IsNotNull(rowsId);
+            long rowId = rowsId.Value;
             bool foundValue = false;
             foreach (Cell cell in rows[0].Cells)
             {
@@ -58,6 +63,7 @@ namespace integration_test_sdk_net80
             Sheet createdSheet = smartsheet.SheetResources.CreateSheet(new Sheet.CreateSheetBuilder("new sheet", columnsToCreate).Build());
             Assert.IsTrue(createdSheet.Columns.Count == 3);
             Assert.IsTrue(createdSheet.Columns[1].Title == "col 2");
+            Assert.IsNotNull(createdSheet.Id);
             return createdSheet.Id.Value;
         }
     }

--- a/integration-test-sdk-net80/ColumnResourcesTest.cs
+++ b/integration-test-sdk-net80/ColumnResourcesTest.cs
@@ -42,7 +42,10 @@ namespace integration_test_sdk_net80
             PaginatedResult<Column> columnsResult = smartsheet.SheetResources.ColumnResources.ListColumns(sheetId, new ColumnInclusion[] { ColumnInclusion.FILTERS });
             Assert.IsTrue(columnsResult.TotalCount == 4);
             Assert.IsTrue(columnsResult.Data.Count == 4);
-            return columnsResult.Data[3].Id.Value;
+
+            var columnsResultThirdId = columnsResult.Data[3].Id;
+            Assert.IsNotNull(columnsResultThirdId);
+            return columnsResultThirdId.Value;
         }
 
         private static void UpdateColumn(SmartsheetClient smartsheet, long sheetId, long columnId)
@@ -65,7 +68,11 @@ namespace integration_test_sdk_net80
             IList<Column> columnsAdded = smartsheet.SheetResources.ColumnResources.AddColumns(sheetId, new Column[] { col });
             Assert.IsTrue(columnsAdded.Count == 1);
             Assert.IsNotNull(columnsAdded[0].Formula);
-            return columnsAdded[0].Id.Value;
+
+            var columnsAddedId = columnsAdded[0].Id;
+            Assert.IsNotNull(columnsAddedId);
+
+            return columnsAddedId.Value;
         }
 
         private static void ClearColumnFormula(SmartsheetClient smartsheet, long sheetId, long columnId)
@@ -86,6 +93,7 @@ namespace integration_test_sdk_net80
             Sheet createdSheet = smartsheet.SheetResources.CreateSheet(new Sheet.CreateSheetBuilder("new sheet", columnsToCreate).Build());
             Assert.IsTrue(createdSheet.Columns.Count == 3);
             Assert.IsTrue(createdSheet.Columns[1].Title == "col 2");
+            Assert.IsNotNull(createdSheet.Id);
             return createdSheet.Id.Value;
         }
     }

--- a/integration-test-sdk-net80/CommentResourcesTest.cs
+++ b/integration-test-sdk-net80/CommentResourcesTest.cs
@@ -46,6 +46,7 @@ namespace integration_test_sdk_net80
         private static void GetComment(SmartsheetClient smartsheet, long sheetId, long commentId)
         {
             Comment getComment = smartsheet.SheetResources.CommentResources.GetComment(sheetId, commentId);
+            Assert.IsNotNull(getComment.Id);
             Assert.IsTrue(getComment.Id.Value == commentId);
             Assert.IsTrue(getComment.Text == "commented2");
         }
@@ -58,8 +59,10 @@ namespace integration_test_sdk_net80
             Assert.IsTrue(addedCommentWithAttachment.Text == "commented2");
             Assert.IsTrue(addedCommentWithAttachment.Attachments.Count == 1);
             Assert.IsTrue(addedCommentWithAttachment.Attachments[0].Name == "TestFile.txt");
-            long commentId = addedCommentWithAttachment.Id.Value;
-            return commentId;
+
+            var commentId = addedCommentWithAttachment.Id;
+            Assert.IsNotNull(commentId);
+            return commentId.Value;
         }
 
         private static void AddCommentWithoutAttachment(SmartsheetClient smartsheet, long sheetId, long discussionId)
@@ -78,8 +81,9 @@ namespace integration_test_sdk_net80
             Discussion discussion2 = smartsheet.SheetResources.DiscussionResources.CreateDiscussionWithAttachment(sheetId, new Discussion.CreateDiscussionBuilder("a discussion", commentToAdd).Build(), path, null);
             Assert.IsTrue(discussion2.Comments[0].Attachments[0].Name == "TestFile.txt");
             
-            long discussionId = discussion.Id.Value;
-            return discussionId;
+            var discussionId = discussion.Id;
+            Assert.IsNotNull(discussionId);
+            return discussionId.Value;
         }
         private static long CreateSheet(SmartsheetClient smartsheet)
         {
@@ -91,6 +95,7 @@ namespace integration_test_sdk_net80
             Sheet createdSheet = smartsheet.SheetResources.CreateSheet(new Sheet.CreateSheetBuilder("new sheet", columnsToCreate).Build());
             Assert.IsTrue(createdSheet.Columns.Count == 3);
             Assert.IsTrue(createdSheet.Columns[1].Title == "col 2");
+            Assert.IsNotNull(createdSheet.Id);
             return createdSheet.Id.Value;
         }
     }

--- a/integration-test-sdk-net80/CrossSheetReferencesTest.cs
+++ b/integration-test-sdk-net80/CrossSheetReferencesTest.cs
@@ -1,13 +1,14 @@
-﻿using Smartsheet.Api.Models;
+﻿using RestSharp;
+using Smartsheet.Api.Models;
 
 namespace integration_test_sdk_net80
 {
     [TestClass]
     public class CrossSheetReferencesTest : TestResources
     {
-        private Sheet sheetA;
-        private Sheet sheetB;
-        private CrossSheetReference xref;
+        private Sheet? sheetA;
+        private Sheet? sheetB;
+        private CrossSheetReference? xref;
 
         [TestInitialize]
         public void Setup()
@@ -21,6 +22,8 @@ namespace integration_test_sdk_net80
         [TestCleanup]
         public void Cleanup()
         {
+            Assert.IsNotNull(sheetA?.Id);
+            Assert.IsNotNull(sheetB?.Id);
             DeleteSheet(sheetA.Id.Value);
             DeleteSheet(sheetB.Id.Value);
         }
@@ -35,31 +38,48 @@ namespace integration_test_sdk_net80
 
         private void TestCreateCrossSheetReference()
         {
+            Assert.IsNotNull(sheetA?.Id);
+            Assert.IsNotNull(sheetB?.Id);
+            var sheetBColumns = sheetB.Columns[0].Id;
+            Assert.IsNotNull(sheetBColumns);
+            var sheetBRows = sheetB.Rows[0].Id;
+            Assert.IsNotNull(sheetBRows);
+
             xref = new CrossSheetReference();
             xref.SourceSheetId = sheetB.Id.Value;
-            xref.StartColumnId = sheetB.Columns[0].Id.Value;
-            xref.EndColumnId = sheetB.Columns[0].Id.Value;
-            xref.StartRowId = sheetB.Rows[0].Id.Value;
-            xref.EndRowId = sheetB.Rows[0].Id.Value;
+            xref.StartColumnId = sheetBColumns.Value;
+            xref.EndColumnId = sheetBColumns.Value;
+            xref.StartRowId = sheetBRows.Value;
+            xref.EndRowId = sheetBRows.Value;
+            Assert.IsNotNull(smartsheet);
             xref = smartsheet.SheetResources.CrossSheetReferenceResources.CreateCrossSheetReference(sheetA.Id.Value, xref);
         }
 
         private void TestListCrossSheetReferences()
         {
             PaginationParameters pagination = new PaginationParameters(true, null, null);
+            Assert.IsNotNull(sheetA?.Id);
+            Assert.IsNotNull(smartsheet);
             PaginatedResult<CrossSheetReference> xrefs = smartsheet.SheetResources.CrossSheetReferenceResources.ListCrossSheetReferences(sheetA.Id.Value, pagination);
-            Assert.AreEqual(xrefs.Data[0].Id.Value, xref.Id.Value);
+            var xrefsDataId = xrefs.Data[0].Id;
+            Assert.IsNotNull(xrefsDataId);
+            Assert.IsNotNull(xref?.Id);
+            Assert.AreEqual(xrefsDataId.Value, xref.Id.Value);
 
             xrefs = smartsheet.SheetResources.CrossSheetReferenceResources.ListCrossSheetReferences(sheetA.Id.Value);
-            Assert.AreEqual(xrefs.Data[0].Id.Value, xref.Id.Value);
+            Assert.AreEqual(xrefsDataId.Value, xref.Id.Value);
         }
 
         private void TestGetCrossSheetReference()
         {
+            Assert.IsNotNull(sheetA?.Id);
+            Assert.IsNotNull(smartsheet);
             Sheet sheet = smartsheet.SheetResources.GetSheet(sheetA.Id.Value, new List<SheetLevelInclusion> { SheetLevelInclusion.CROSS_SHEET_REFERENCES });
             Assert.IsTrue(sheet.CrossSheetReferences.Count == 1);
 
-            CrossSheetReference _xref = smartsheet.SheetResources.CrossSheetReferenceResources.GetCrossSheetReference(sheetA.Id.Value, sheet.CrossSheetReferences[0].Id.Value);
+            var sheetCrossReferenceId = sheet.CrossSheetReferences[0].Id;
+            Assert.IsNotNull(sheetCrossReferenceId);
+            CrossSheetReference _xref = smartsheet.SheetResources.CrossSheetReferenceResources.GetCrossSheetReference(sheetA.Id.Value, sheetCrossReferenceId.Value);
         }
     }
 }

--- a/integration-test-sdk-net80/DiscussionResourcesTest.cs
+++ b/integration-test-sdk-net80/DiscussionResourcesTest.cs
@@ -15,6 +15,7 @@ namespace integration_test_sdk_net80
 
             Discussion discussionToCreate = new Discussion.CreateDiscussionBuilder("A discussion", new Comment.AddCommentBuilder("a comment").Build()).Build();
             Discussion createdDiscussion = smartsheet.SheetResources.DiscussionResources.CreateDiscussion(sheetId, discussionToCreate);
+            Assert.IsNotNull(createdDiscussion.Id);
             long createdDiscussionId = createdDiscussion.Id.Value;
             string path = "../../../../integration-test-sdk-net80/TestFile.txt";
             Discussion createdDiscussionWithFile = smartsheet.SheetResources.DiscussionResources.CreateDiscussionWithAttachment(sheetId, discussionToCreate, path, null);
@@ -24,8 +25,14 @@ namespace integration_test_sdk_net80
             PaginatedResult<Discussion> discussions = smartsheet.SheetResources.DiscussionResources.ListDiscussions(sheetId, new DiscussionInclusion[] { DiscussionInclusion.COMMENTS, DiscussionInclusion.ATTACHMENTS });
             Assert.IsTrue(discussions.TotalCount == 2);
             Assert.IsTrue(discussions.Data.Count == 2);
-            Assert.IsTrue(discussions.Data[0].Id.Value == createdDiscussion.Id.Value || discussions.Data[0].Id.Value == createdDiscussionWithFile.Id.Value);
-            Assert.IsTrue(discussions.Data[1].Id.Value == createdDiscussion.Id.Value || discussions.Data[1].Id.Value == createdDiscussionWithFile.Id.Value);
+            var discussionIds = discussions.Data.Select(d => d.Id.Value).ToList();
+            var discussionDataFirst = discussions.Data[0].Id;
+            var discussionDataSecond = discussions.Data[1].Id;
+            Assert.IsNotNull(discussionDataFirst);
+            Assert.IsNotNull(discussionDataSecond);
+            Assert.IsNotNull(createdDiscussionWithFile.Id);
+            Assert.IsTrue(discussionDataFirst.Value == createdDiscussion.Id.Value || discussionDataFirst.Value == createdDiscussionWithFile.Id.Value);
+            Assert.IsTrue(discussionDataSecond.Value == createdDiscussion.Id.Value || discussionDataSecond.Value == createdDiscussionWithFile.Id.Value);
 
 
             Discussion getDiscussionWithFile = smartsheet.SheetResources.DiscussionResources.GetDiscussion(sheetId, createdDiscussionWithFile.Id.Value);
@@ -37,8 +44,9 @@ namespace integration_test_sdk_net80
             Row row = new Row.AddRowBuilder(true, null, null, null, null).Build();
             IList<Row> rows = smartsheet.SheetResources.RowResources.AddRows(sheetId, new Row[] { row });
             Assert.IsTrue(rows.Count == 1);
-            Assert.IsTrue(rows[0].Id.HasValue);
-            long rowId = rows[0].Id.Value;
+            var rowsId = rows[0].Id;
+            Assert.IsNotNull(rowsId);
+            long rowId = rowsId.Value;
             Comment comment = new Comment.AddCommentBuilder("a comment!").Build();
             Discussion discussionToCreateOnRow = new Discussion.CreateDiscussionBuilder("discussion on row", comment).Build();
             Discussion discussionCreatedOnRow = smartsheet.SheetResources.RowResources.DiscussionResources.CreateDiscussionWithAttachment(sheetId, rowId, discussionToCreateOnRow, path, null);
@@ -61,6 +69,7 @@ namespace integration_test_sdk_net80
             Sheet createdSheet = smartsheet.SheetResources.CreateSheet(new Sheet.CreateSheetBuilder("new sheet", columnsToCreate).Build());
             Assert.IsTrue(createdSheet.Columns.Count == 3);
             Assert.IsTrue(createdSheet.Columns[1].Title == "col 2");
+            Assert.IsNotNull(createdSheet.Id);
             return createdSheet.Id.Value;
         }
     }

--- a/integration-test-sdk-net80/FavoriteResourcesTest.cs
+++ b/integration-test-sdk-net80/FavoriteResourcesTest.cs
@@ -71,6 +71,7 @@ namespace integration_test_sdk_net80
                 ObjectType type = ObjectType.FOLDER;
                 foreach (Favorite fav in favsToDelete.Data)
                 {
+                    Assert.IsNotNull(fav.ObjectId);
                     switch (i)
                     {
                         case 0:
@@ -130,6 +131,7 @@ namespace integration_test_sdk_net80
         private static long CreateWorkspace(SmartsheetClient smartsheet)
         {
             Workspace ws = smartsheet.WorkspaceResources.CreateWorkspace(new Workspace.CreateWorkspaceBuilder("workspace").Build());
+            Assert.IsNotNull(ws.Id);
             long workspaceId = ws.Id.Value;
             return workspaceId;
         }
@@ -137,6 +139,7 @@ namespace integration_test_sdk_net80
         private static long CreateFolder(SmartsheetClient smartsheet)
         {
             Folder folder = smartsheet.HomeResources.FolderResources.CreateFolder(new Folder.CreateFolderBuilder("folder").Build());
+            Assert.IsNotNull(folder.Id);
             long folderId = folder.Id.Value;
             return folderId;
         }
@@ -148,6 +151,7 @@ namespace integration_test_sdk_net80
             new Group.CreateGroupBuilder("a group", "this is a group").SetMembers(new GroupMember[] { member }).Build());
 
             Assert.IsTrue(group.Name == "a group");
+            Assert.IsNotNull(group.Id);
             return group.Id.Value;
         }
 
@@ -161,6 +165,7 @@ namespace integration_test_sdk_net80
             Sheet createdSheet = smartsheet.SheetResources.CreateSheet(new Sheet.CreateSheetBuilder("new sheet", columnsToCreate).Build());
             Assert.IsTrue(createdSheet.Columns.Count == 3);
             Assert.IsTrue(createdSheet.Columns[1].Title == "col 2");
+            Assert.IsNotNull(createdSheet.Id);
             return createdSheet.Id.Value;
         }
     }

--- a/integration-test-sdk-net80/FolderResourcesCopyTest.cs
+++ b/integration-test-sdk-net80/FolderResourcesCopyTest.cs
@@ -31,7 +31,7 @@ namespace integration_test_sdk_net80
             Folder newCopiedFolder = smartsheet.FolderResources.CopyFolder(createdFolderInFolderId, destination, new FolderCopyInclusion[] { FolderCopyInclusion.ALL }, new FolderRemapExclusion[] { FolderRemapExclusion.CELL_LINKS });
 
             Assert.IsTrue(newCopiedFolder.Name == "SubFolder1Copy");
-
+            Assert.IsNotNull(newCopiedFolder.Id);
             long copiedFolderId = newCopiedFolder.Id.Value;
 
             Folder copiedFolder = smartsheet.FolderResources.GetFolder(copiedFolderId);
@@ -68,12 +68,14 @@ namespace integration_test_sdk_net80
         private static long CreateFolderInFolder(SmartsheetClient smartsheet, long createdFolderInHomeId, string folderName)
         {
             Folder createdFolderInFolder = smartsheet.FolderResources.CreateFolder(createdFolderInHomeId, new Folder.CreateFolderBuilder(folderName).Build());
+            Assert.IsNotNull(createdFolderInFolder.Id);
             return createdFolderInFolder.Id.Value;
         }
 
         private static long CreateFolderInHome(SmartsheetClient smartsheet, string folderName)
         {
             Folder createdFolderInHome = smartsheet.HomeResources.FolderResources.CreateFolder(new Folder.CreateFolderBuilder(folderName).Build());
+            Assert.IsNotNull(createdFolderInHome.Id);
             return createdFolderInHome.Id.Value;
         }
     }

--- a/integration-test-sdk-net80/FolderResourcesMoveTest.cs
+++ b/integration-test-sdk-net80/FolderResourcesMoveTest.cs
@@ -32,6 +32,7 @@ namespace integration_test_sdk_net80
 
             Assert.IsTrue(newMovedFolder.Name == "SubFolder1");
 
+            Assert.IsNotNull(newMovedFolder.Id);
             long movedFolderId = newMovedFolder.Id.Value;
 
             Folder movedFolder = smartsheet.FolderResources.GetFolder(movedFolderId);
@@ -73,12 +74,14 @@ namespace integration_test_sdk_net80
         private static long CreateFolderInFolder(SmartsheetClient smartsheet, long createdFolderInHomeId, string folderName)
         {
             Folder createdFolderInFolder = smartsheet.FolderResources.CreateFolder(createdFolderInHomeId, new Folder.CreateFolderBuilder(folderName).Build());
+            Assert.IsNotNull(createdFolderInFolder.Id);
             return createdFolderInFolder.Id.Value;
         }
 
         private static long CreateFolderInHome(SmartsheetClient smartsheet, string folderName)
         {
             Folder createdFolderInHome = smartsheet.HomeResources.FolderResources.CreateFolder(new Folder.CreateFolderBuilder(folderName).Build());
+            Assert.IsNotNull(createdFolderInHome.Id);
             return createdFolderInHome.Id.Value;
         }
     }

--- a/integration-test-sdk-net80/FolderResourcesTest.cs
+++ b/integration-test-sdk-net80/FolderResourcesTest.cs
@@ -114,6 +114,7 @@ namespace integration_test_sdk_net80
         {
             Folder createdFolderInFolder = smartsheet.FolderResources.CreateFolder(createdFolderInHomeId, new Folder.CreateFolderBuilder(folderInFolderName).Build());
             Assert.IsTrue(createdFolderInFolder.Name == folderInFolderName);
+            Assert.IsNotNull(createdFolderInFolder.Id);
             return createdFolderInFolder.Id.Value;
         }
 
@@ -121,6 +122,7 @@ namespace integration_test_sdk_net80
         {
             Folder createdFolderInHome = smartsheet.HomeResources.FolderResources.CreateFolder(new Folder.CreateFolderBuilder(folderInHomeName).Build());
             Assert.IsTrue(createdFolderInHome.Name == folderInHomeName);
+            Assert.IsNotNull(createdFolderInHome.Id);
             return createdFolderInHome.Id.Value;
         }
     }

--- a/integration-test-sdk-net80/GroupResourcesTest.cs
+++ b/integration-test-sdk-net80/GroupResourcesTest.cs
@@ -95,6 +95,7 @@ namespace integration_test_sdk_net80
             Group group = smartsheet.GroupResources.CreateGroup(new Group.CreateGroupBuilder("a group", "this is a group").SetMembers(new GroupMember[] { member }).Build());
 
             Assert.IsTrue(group.Name == "a group");
+            Assert.IsNotNull(group.Id);
             return group.Id.Value;
         }
     }

--- a/integration-test-sdk-net80/MultiPicklistTest.cs
+++ b/integration-test-sdk-net80/MultiPicklistTest.cs
@@ -6,7 +6,7 @@ namespace integration_test_sdk_net80
     public class MultiPicklistTest : TestResources
     {
         private long sheetId;
-        IList<Column> addCols;
+        IList<Column>? addCols;
 
         [TestInitialize]
         public void TestInitialize()
@@ -43,12 +43,14 @@ namespace integration_test_sdk_net80
                 Type = ColumnType.MULTI_PICKLIST,
                 Options = new string[] { "Cat", "Rat", "Bat" }
             };
+            Assert.IsNotNull(smartsheet);
             addCols = smartsheet.SheetResources.ColumnResources.AddColumns(sheetId, new Column[] { mpl });
             Assert.AreEqual(addCols.Count, 1);
         }
 
         private void TestListMultiPicklistColumn()
         {
+            Assert.IsNotNull(smartsheet);
             PaginatedResult<Column> cols = smartsheet.SheetResources.ColumnResources.ListColumns(sheetId);
             // should be TEXT_NUMBER since level not specified
             Assert.AreEqual(cols.Data[0].Type, ColumnType.TEXT_NUMBER);
@@ -60,6 +62,7 @@ namespace integration_test_sdk_net80
 
         private void TestAddMultiPicklistRow()
         {
+            Assert.IsNotNull(addCols);
             Cell[] insert_cells = new Cell[]
             {
                 new Cell
@@ -73,18 +76,23 @@ namespace integration_test_sdk_net80
                 ToTop = true,
                 Cells = insert_cells
             };
+            Assert.IsNotNull(smartsheet);
             IList<Row> insert_rows = smartsheet.SheetResources.RowResources.AddRows(sheetId, new Row[] { insert_row });
             Assert.AreEqual(insert_rows.Count, 1);
         }
 
         private void TestGetMultiPicklistSheet()
         {
+            Assert.IsNotNull(addCols);
+            var addColsId = addCols[0].Id;
+            Assert.IsNotNull(addColsId);
+            Assert.IsNotNull(smartsheet);
             Sheet mpl = smartsheet.SheetResources.GetSheet(sheetId,
-             new List<SheetLevelInclusion> { SheetLevelInclusion.OBJECT_VALUE }, columnIds: new List<long> { addCols[0].Id.Value });
+             new List<SheetLevelInclusion> { SheetLevelInclusion.OBJECT_VALUE }, columnIds: new List<long> { addColsId.Value });
             // should be TEXT_NUMBER since level not specified
             Assert.AreEqual(mpl.Rows[0].Cells[0].ObjectValue.GetType(), typeof(StringObjectValue));
 
-            mpl = smartsheet.SheetResources.GetSheet(sheetId, new List<SheetLevelInclusion> { SheetLevelInclusion.OBJECT_VALUE }, columnIds: new List<long> { addCols[0].Id.Value }, level: 2);
+            mpl = smartsheet.SheetResources.GetSheet(sheetId, new List<SheetLevelInclusion> { SheetLevelInclusion.OBJECT_VALUE }, columnIds: new List<long> { addColsId.Value }, level: 2);
             // should be MULTI_PICKLIST since level 2 specified
             Assert.AreEqual(mpl.Rows[0].Cells[0].ObjectValue.GetType(), typeof(MultiPicklistObjectValue));
         }

--- a/integration-test-sdk-net80/PassthroughResourcesTest.cs
+++ b/integration-test-sdk-net80/PassthroughResourcesTest.cs
@@ -23,20 +23,24 @@ namespace integration_test_sdk_net80
 
             long id = 0;
             JsonReader reader = new JsonTextReader(new StringReader(jsonResponse));
+
             while(id == 0 && reader.Read()) {
                 switch (reader.TokenType)
                 {
                     case JsonToken.StartObject:
                         break;
                     case JsonToken.PropertyName:
-                        if(reader.Value.ToString().Contains("message")) 
+                        var value = reader.Value?.ToString();
+                        Assert.IsNotNull(value);
+                        if(value.Contains("message")) 
                         {
-                            string message = reader.ReadAsString();
+                            string message = reader.ReadAsString() ?? string.Empty;
                             Assert.AreEqual(message, "SUCCESS");
                         }
-                        else if(reader.Value.ToString().Contains("id"))
+                        else if(value.Contains("id"))
                         {
                             reader.Read();
+                            Assert.IsNotNull(reader.Value);
                             id = (long)reader.Value;
                         }
                         else
@@ -54,9 +58,10 @@ namespace integration_test_sdk_net80
             IDictionary<string, string> parameters = new Dictionary<string,string>();
             parameters.Add("include", "objectValue");
             jsonResponse = smartsheet.PassthroughResources.GetRequest("sheets/" + id, parameters);
-
-            string name = null;
             reader = new JsonTextReader(new StringReader(jsonResponse));
+            Assert.IsNotNull(reader.Value);
+
+            string? name = null;
             while (name == null && reader.Read())
             {
                 switch (reader.TokenType)
@@ -64,9 +69,14 @@ namespace integration_test_sdk_net80
                     case JsonToken.StartObject:
                         break;
                     case JsonToken.PropertyName:
-                        if (reader.Value.ToString().Contains("name"))
+
+                        var value = reader.Value.ToString();
+                        Assert.IsNotNull(value);
+                        if (value.Contains("name"))
                         {
-                            name = reader.ReadAsString();
+                            var nameValue = reader.ReadAsString();
+                            Assert.IsNotNull(nameValue);
+                            name = nameValue;
                         }
                         else
                         {
@@ -92,7 +102,7 @@ namespace integration_test_sdk_net80
                     case JsonToken.StartObject:
                         break;
                     case JsonToken.PropertyName:
-                        if (reader.Value.ToString().Contains("name"))
+                        if ((reader.Value?.ToString() ?? string.Empty) .Contains("name"))
                         {
                             name = reader.ReadAsString();
                         }
@@ -119,9 +129,9 @@ namespace integration_test_sdk_net80
                     case JsonToken.StartObject:
                         break;
                     case JsonToken.PropertyName:
-                        if (reader.Value.ToString().Contains("message"))
+                        if ((reader.Value?.ToString() ?? string.Empty).Contains("message"))
                         {
-                            string message = reader.ReadAsString();
+                            string? message = reader.ReadAsString();
                             Assert.AreEqual(message, "SUCCESS");
                             success = true;
                         }

--- a/integration-test-sdk-net80/RowResourcesTest.cs
+++ b/integration-test-sdk-net80/RowResourcesTest.cs
@@ -1,4 +1,5 @@
-﻿using Smartsheet.Api;
+﻿using RestSharp;
+using Smartsheet.Api;
 using Smartsheet.Api.Models;
 
 namespace integration_test_sdk_net80
@@ -11,11 +12,15 @@ namespace integration_test_sdk_net80
         {
             SmartsheetClient smartsheet = new SmartsheetBuilder().SetMaxRetryTimeout(30000).Build();
 
-            long templateId = smartsheet.TemplateResources.ListPublicTemplates().Data[0].Id.Value;
+            var templateDataId = smartsheet.TemplateResources.ListPublicTemplates().Data[0].Id;
+            Assert.IsNotNull(templateDataId);
+            long templateId = templateDataId.Value;
             long sheetId = CreateSheetFromTemplate(smartsheet, templateId);
 
             PaginatedResult<Column> columnsResult = smartsheet.SheetResources.ColumnResources.ListColumns(sheetId);
-            long columnId = columnsResult.Data[0].Id.Value;
+            var columnDataId = columnsResult.Data[0].Id;
+            Assert.IsNotNull(columnDataId);
+            long columnId = columnDataId.Value;
 
             Cell[] cellsToAdd = new Cell[] { new Cell.AddCellBuilder(columnId, true).SetValue("hello").SetStrict(false).Build() };
 
@@ -68,7 +73,9 @@ namespace integration_test_sdk_net80
 
         private static void CopyRowToCreatedSheet(SmartsheetClient smartsheet, long sheetId, long rowId)
         {
-            long tempSheetId = smartsheet.SheetResources.CreateSheet(new Sheet.CreateSheetBuilder("tempSheet", new Column[] { new Column.CreateSheetColumnBuilder("col1", true, ColumnType.TEXT_NUMBER).Build() }).Build()).Id.Value;
+            var tempSheet = smartsheet.SheetResources.CreateSheet(new Sheet.CreateSheetBuilder("tempSheet", new Column[] { new Column.CreateSheetColumnBuilder("col1", true, ColumnType.TEXT_NUMBER).Build() }).Build()).Id;
+            Assert.IsNotNull(tempSheet);
+            long tempSheetId = tempSheet.Value;
             CopyOrMoveRowDestination destination = new CopyOrMoveRowDestination { SheetId = tempSheetId };
             CopyOrMoveRowDirective directive = new CopyOrMoveRowDirective { RowIds = new long[] { rowId }, To = destination };
             CopyOrMoveRowResult result = smartsheet.SheetResources.RowResources.CopyRowsToAnotherSheet(sheetId, directive, new CopyRowInclusion[] { CopyRowInclusion.CHILDREN }, false);
@@ -80,7 +87,9 @@ namespace integration_test_sdk_net80
             Row row = new Row.AddRowBuilder(true, null, null, null, null).SetCells(cellsToAdd).Build();
             IList<Row> rows = smartsheet.SheetResources.RowResources.AddRows(sheetId, new Row[] { row });
             Assert.IsTrue(rows.Count == 1);
-            long rowId = rows[0].Id.Value;
+            var rowsId = rows[0].Id;
+            Assert.IsNotNull(rowsId);
+            long rowId = rowsId.Value;
             bool foundValue = false;
             foreach (Cell cell in rows[0].Cells)
             {
@@ -107,7 +116,9 @@ namespace integration_test_sdk_net80
         {
             // Create a new sheet off of that template.
             Sheet newSheet = smartsheet.SheetResources.CreateSheetFromTemplate(new Sheet.CreateSheetFromTemplateBuilder("New Sheet", templateId).Build(), new TemplateInclusion[] { TemplateInclusion.DATA, TemplateInclusion.RULE_RECIPIENTS, TemplateInclusion.RULES });
-            return newSheet.Id.Value;
+            var newSheetId = newSheet.Id;
+            Assert.IsNotNull(newSheetId);
+            return newSheetId.Value;
         }
     }
 }

--- a/integration-test-sdk-net80/SearchingResourcesTest.cs
+++ b/integration-test-sdk-net80/SearchingResourcesTest.cs
@@ -53,7 +53,9 @@ namespace integration_test_sdk_net80
         private static void AddValuesToSheet(SmartsheetClient smartsheet, long sheetId, string query)
         {
             Sheet sheet = smartsheet.SheetResources.GetSheet(sheetId);
-            long columnId = sheet.Columns[0].Id.Value;
+            var sheetColumns = sheet.Columns[0].Id;
+            Assert.IsNotNull(sheetColumns);
+            long columnId = sheetColumns.Value;
             Cell cell = new Cell.AddCellBuilder(columnId, query).SetStrict(false).Build();
             Row[] rows = new Row[] { new Row.AddRowBuilder(true, null, null, null, false).SetCells(new Cell[] { cell }).Build() };
 
@@ -70,6 +72,7 @@ namespace integration_test_sdk_net80
             Sheet createdSheet = smartsheet.SheetResources.CreateSheet(new Sheet.CreateSheetBuilder("new sheet", columnsToCreate).Build());
             Assert.IsTrue(createdSheet.Columns.Count == 3);
             Assert.IsTrue(createdSheet.Columns[1].Title == "col 2");
+            Assert.IsNotNull(createdSheet.Id);
             return createdSheet.Id.Value;
         }
 

--- a/integration-test-sdk-net80/ShareResourcesTest.cs
+++ b/integration-test-sdk-net80/ShareResourcesTest.cs
@@ -76,6 +76,7 @@ namespace integration_test_sdk_net80
         private static long CreateWorkspace(SmartsheetClient smartsheet)
         {
             Workspace ws = smartsheet.WorkspaceResources.CreateWorkspace(new Workspace.CreateWorkspaceBuilder("workspace").Build());
+            Assert.IsNotNull(ws.Id);
             long workspaceId = ws.Id.Value;
             return workspaceId;
         }
@@ -84,7 +85,9 @@ namespace integration_test_sdk_net80
         {
             PaginatedResult<Report> reportResult = smartsheet.ReportResources.ListReports(null);
             Assert.IsTrue(reportResult.Data.Count > 0);
-            long reportId = reportResult.Data[0].Id.Value;
+            var reportResultData = reportResult.Data[0];
+            Assert.IsNotNull(reportResultData.Id);
+            long reportId = reportResultData.Id.Value;
             return reportId;
         }
 
@@ -95,6 +98,7 @@ namespace integration_test_sdk_net80
             new Group.CreateGroupBuilder("a group", "this is a group").SetMembers(new GroupMember[] { member }).Build());
 
             Assert.IsTrue(group.Name == "a group");
+            Assert.IsNotNull(group.Id);
             return group.Id.Value;
         }
 
@@ -108,6 +112,7 @@ namespace integration_test_sdk_net80
             Sheet createdSheet = smartsheet.SheetResources.CreateSheet(new Sheet.CreateSheetBuilder("new sheet", columnsToCreate).Build());
             Assert.IsTrue(createdSheet.Columns.Count == 3);
             Assert.IsTrue(createdSheet.Columns[1].Title == "col 2");
+            Assert.IsNotNull(createdSheet.Id);
             return createdSheet.Id.Value;
         }
     }

--- a/integration-test-sdk-net80/SheetResourcesTest.cs
+++ b/integration-test-sdk-net80/SheetResourcesTest.cs
@@ -5,11 +5,11 @@ namespace integration_test_sdk_net80
     [TestClass]
     public class SheetResourcesTest : TestResources
     {
-        private Sheet sheetHome;
-        private Sheet newSheetHome;
-        private Sheet newSheetTemplate;
-        private Folder folder;
-        private Workspace workspace;
+        private Sheet? sheetHome;
+        private Sheet? newSheetHome;
+        private Sheet? newSheetTemplate;
+        private Folder? folder;
+        private Workspace? workspace;
 
         [TestInitialize]
         public void TestInitialize()
@@ -46,6 +46,7 @@ namespace integration_test_sdk_net80
         private void TestCreateSheetHome()
         {
             sheetHome = CreateSheetObject();
+            Assert.IsNotNull(smartsheet);
             newSheetHome = smartsheet.SheetResources.CreateSheet(sheetHome);
             if(newSheetHome.Columns.Count != sheetHome.Columns.Count)
             {
@@ -61,6 +62,8 @@ namespace integration_test_sdk_net80
             destination.DestinationType = DestinationType.FOLDER;
             destination.DestinationId = folder.Id;
             destination.NewName = "CSharp SDK Copied Sheet";
+            Assert.IsNotNull(newSheetHome?.Id);
+            Assert.IsNotNull(smartsheet);
             Sheet sheet = smartsheet.SheetResources.CopySheet(newSheetHome.Id.Value, destination,
                 new List<SheetCopyInclusion> { SheetCopyInclusion.ALL });
             Assert.IsTrue(sheet.Name == "CSharp SDK Copied Sheet");
@@ -68,27 +71,34 @@ namespace integration_test_sdk_net80
             destination.NewName = "CSharp SDK Copied Sheet Without Inclusions";
             sheet = smartsheet.SheetResources.CopySheet(newSheetHome.Id.Value, destination);
             Assert.IsTrue(sheet.Name == "CSharp SDK Copied Sheet Without Inclusions");
+            Assert.IsNotNull(folder.Id);
             DeleteFolder(folder.Id.Value);
         }
 
         private void TestMoveSheet()
         {
             Folder folder = CreateFolderHome();
+            Assert.IsNotNull(smartsheet);
             Sheet sheet = smartsheet.SheetResources.CreateSheet(CreateSheetObject());
 
             ContainerDestination destination = new ContainerDestination();
             destination.DestinationType = DestinationType.FOLDER;
             destination.DestinationId = folder.Id;
 
+            Assert.IsNotNull(sheet.Id);
             Sheet movedSheet = smartsheet.SheetResources.MoveSheet(sheet.Id.Value, destination);
             Assert.IsNotNull(movedSheet);
+            Assert.IsNotNull(movedSheet.Id);
             DeleteSheet(movedSheet.Id.Value);
+            Assert.IsNotNull(folder.Id);
             DeleteFolder(folder.Id.Value);
         }
 
         private void TestCreateSheetHomeFromTemplate()
         {
+            Assert.IsNotNull(newSheetHome?.Id);
             Sheet sheet = new Sheet.CreateSheetFromTemplateBuilder("CSharp SDK Sheet from Template", newSheetHome.Id.Value).Build();
+            Assert.IsNotNull(smartsheet);
             newSheetTemplate = smartsheet.SheetResources.CreateSheetFromTemplate(sheet,
                 new List<TemplateInclusion> { TemplateInclusion.ATTACHMENTS, TemplateInclusion.DATA, TemplateInclusion.DISCUSSIONS, TemplateInclusion.RULE_RECIPIENTS, TemplateInclusion.RULES });
             Assert.AreEqual(AccessLevel.OWNER, newSheetTemplate.AccessLevel);
@@ -97,6 +107,9 @@ namespace integration_test_sdk_net80
         private void TestCreateSheetInFolder()
         {
             folder = CreateFolderHome();
+            Assert.IsNotNull(folder.Id);
+            Assert.IsNotNull(smartsheet);
+            Assert.IsNotNull(sheetHome);
             Sheet newSheetFolder = smartsheet.FolderResources.SheetResources.CreateSheet(folder.Id.Value, sheetHome);
 
             if(newSheetFolder.Columns.Count != sheetHome.Columns.Count)
@@ -107,10 +120,13 @@ namespace integration_test_sdk_net80
 
         private void TestCreateSheetInFolderFromTemplate()
         {
+            Assert.IsNotNull(newSheetHome?.Id);
+            Assert.IsNotNull(folder?.Id);
             Sheet sheet = new Sheet.CreateSheetFromTemplateBuilder("CSharp SDK Sheet from Template", newSheetHome.Id.Value).Build();
+            Assert.IsNotNull(smartsheet);
             Sheet newSheetFromTemplate = smartsheet.FolderResources.SheetResources.CreateSheetFromTemplate(folder.Id.Value, sheet);
 
-            if(newSheetFromTemplate.Id.ToString().Length == 0 || newSheetFromTemplate.AccessLevel != AccessLevel.OWNER ||
+            if(newSheetFromTemplate?.Id?.ToString().Length == 0 || newSheetFromTemplate?.AccessLevel != AccessLevel.OWNER ||
                 newSheetFromTemplate.Permalink.Length == 0)
             {
                 Assert.Fail("SheetResourcesTest.TestCreateSheetInFolderFromTemplate Failed to create sheet");
@@ -120,16 +136,22 @@ namespace integration_test_sdk_net80
         private void TestCreateSheetInWorkspace()
         {
             workspace = CreateWorkspace("CSharp Test Workspace");
+            Assert.IsNotNull(workspace.Id);
+            Assert.IsNotNull(smartsheet);
+            Assert.IsNotNull(sheetHome);
             Sheet newSheet = smartsheet.WorkspaceResources.SheetResources.CreateSheet(workspace.Id.Value, sheetHome);
             Assert.AreEqual(sheetHome.Columns.Count, newSheet.Columns.Count);
         }
 
         private void TestCreateSheetInWorkspaceFromTemplate()
         {
+            Assert.IsNotNull(newSheetHome?.Id);
+            Assert.IsNotNull(workspace?.Id);
             Sheet sheet = new Sheet.CreateSheetFromTemplateBuilder("CSharp SDK Sheet in Workspace from Template", newSheetHome.Id.Value).Build();
+            Assert.IsNotNull(smartsheet);
             Sheet newSheetFromTemplate = smartsheet.WorkspaceResources.SheetResources.CreateSheetFromTemplate(workspace.Id.Value, sheet,
                 new List<TemplateInclusion> { TemplateInclusion.ATTACHMENTS, TemplateInclusion.DATA, TemplateInclusion.DISCUSSIONS, TemplateInclusion.RULE_RECIPIENTS, TemplateInclusion.RULES });
-            if (newSheetFromTemplate.Id.ToString().Length == 0 || newSheetFromTemplate.AccessLevel != AccessLevel.OWNER ||
+            if (newSheetFromTemplate?.Id?.ToString().Length == 0 || newSheetFromTemplate?.AccessLevel != AccessLevel.OWNER ||
                 newSheetFromTemplate.Permalink.Length == 0)
             {
                 Assert.Fail("SheetResourcesTest.TestCreateSheetInWorkspaceFromTemplate Failed to create sheet");
@@ -138,6 +160,8 @@ namespace integration_test_sdk_net80
 
         private void TestGetSheet()
         {
+            Assert.IsNotNull(newSheetHome?.Id);
+            Assert.IsNotNull(smartsheet);
             Sheet sheet = smartsheet.SheetResources.GetSheet(newSheetHome.Id.Value);
             Assert.AreEqual(sheet.Permalink, newSheetHome.Permalink);
 
@@ -149,20 +173,26 @@ namespace integration_test_sdk_net80
 
         private void TestGetSheetVersion()
         {
+            Assert.IsNotNull(newSheetHome?.Id);
+            Assert.IsNotNull(smartsheet);            
             int? version = smartsheet.SheetResources.GetSheetVersion(newSheetHome.Id.Value);
-            if (version.Value != 1)
+            if (version == null || version.Value != 1)
                 Assert.Fail("SheetResourcesTest.TestGetSheetVersion GetSheetVersion incorrect");
         }
 
         private void TestGetSheetAsExcel()
         {
             BinaryWriter writer = new BinaryWriter(new MemoryStream());
+            Assert.IsNotNull(newSheetHome?.Id);
+            Assert.IsNotNull(smartsheet);
             smartsheet.SheetResources.GetSheetAsExcel(newSheetHome.Id.Value, writer);
         }
 
         private void TestGetSheetAsPDF()
         {
             BinaryWriter writer = new BinaryWriter(new MemoryStream());
+            Assert.IsNotNull(newSheetHome?.Id);
+            Assert.IsNotNull(smartsheet);
             smartsheet.SheetResources.GetSheetAsPDF(newSheetHome.Id.Value, writer, PaperSize.A3);
 
             //Test with no size given
@@ -171,13 +201,17 @@ namespace integration_test_sdk_net80
 
         private void TestGetPublishStatus()
         {
+            Assert.IsNotNull(newSheetHome?.Id);
+            Assert.IsNotNull(smartsheet);
             SheetPublish sheetPublish = smartsheet.SheetResources.GetPublishStatus(newSheetHome.Id.Value);
             Assert.IsNotNull(sheetPublish);
         }
 
         private void TestUpdateSheet()
         {
+            Assert.IsNotNull(newSheetHome?.Id);
             Sheet sheet = new Sheet.UpdateSheetBuilder(newSheetHome.Id).SetName("CSharp SDK Updated Sheet").Build();
+            Assert.IsNotNull(smartsheet);
             Sheet newSheet = smartsheet.SheetResources.UpdateSheet(sheet);
             Assert.AreEqual(sheet.Name, newSheet.Name);
         }
@@ -185,8 +219,10 @@ namespace integration_test_sdk_net80
         private void TestPublishSheetDefaults()
         {
             SheetPublish sheetPublish = new SheetPublish.PublishStatusBuilder(true, true, true, false).Build();
+            Assert.IsNotNull(newSheetHome?.Id);
+            Assert.IsNotNull(smartsheet);
             SheetPublish newSheetPublish = smartsheet.SheetResources.UpdatePublishStatus(newSheetHome.Id.Value, sheetPublish);
-            Assert.IsTrue(newSheetPublish.ReadWriteShowToolbar.Value);
+            Assert.IsTrue(newSheetPublish.ReadWriteShowToolbar.GetValueOrDefault(false));
         }
 
         private void TestPublishSheet()
@@ -198,14 +234,20 @@ namespace integration_test_sdk_net80
             sheetPublish.ReadOnlyLiteEnabled = true;
             sheetPublish.ReadWriteShowToolbar = false;
             sheetPublish.ReadOnlyFullShowToolbar = false;
+            Assert.IsNotNull(newSheetHome?.Id);
+            Assert.IsNotNull(smartsheet);
             SheetPublish newSheetPublish = smartsheet.SheetResources.UpdatePublishStatus(newSheetHome.Id.Value, sheetPublish);
+
+            Assert.IsNotNull(newSheetPublish.ReadWriteShowToolbar);
             Assert.IsFalse(newSheetPublish.ReadWriteShowToolbar.Value);
+            Assert.IsNotNull(newSheetPublish.ReadOnlyFullShowToolbar);
             Assert.IsFalse(newSheetPublish.ReadOnlyFullShowToolbar.Value);
         }
 
         private void TestListSheets()
         {
             PaginationParameters pagination = new PaginationParameters(false, 1, 1);
+            Assert.IsNotNull(smartsheet);
             PaginatedResult<Sheet> sheets = smartsheet.SheetResources.ListSheets(new List<SheetInclusion> { SheetInclusion.SOURCE }, pagination);
             Assert.IsTrue(sheets.PageNumber == 1);
         }
@@ -221,18 +263,24 @@ namespace integration_test_sdk_net80
             formatDetails.PaperSize = PaperSize.A4;
 
             SheetEmail email = new SheetEmail.CreateSheetEmail(recipients, SheetEmailFormat.PDF).SetFormatDetails(formatDetails).Build();
+            Assert.IsNotNull(newSheetHome?.Id);
+            Assert.IsNotNull(smartsheet);
             smartsheet.SheetResources.SendSheet(newSheetHome.Id.Value, email);
         }
 
         private void TestCreateUpdateRequest()
         {
+            Assert.IsNotNull(smartsheet);
             Sheet sheet = smartsheet.SheetResources.CreateSheet(CreateSheetObject());
 
             PaginationParameters pagination = new PaginationParameters(true, null, null);
+            Assert.IsNotNull(sheet.Id);
             PaginatedResult<Column> columns = smartsheet.SheetResources.ColumnResources.ListColumns(sheet.Id.Value, new List<ColumnInclusion> { ColumnInclusion.FILTERS }, pagination);
 
             Column addedColumn1 = columns.Data[0];
             Column addedColumn2 = columns.Data[1];
+            Assert.IsNotNull(addedColumn1.Id);
+            Assert.IsNotNull(addedColumn2.Id);
 
             List<Cell> cellsA = new List<Cell> { new Cell.AddCellBuilder(addedColumn1.Id.Value, true).Build(),
                 new Cell.AddCellBuilder(addedColumn2.Id.Value, "new status").Build() };
@@ -256,7 +304,9 @@ namespace integration_test_sdk_net80
             updateRequest.Subject = "some subject";
             updateRequest.Message = "some message";
             updateRequest.CcMe = false;
-            updateRequest.RowIds = new List<long> { newRows[0].Id.Value };
+            var rowId = newRows[0].Id.GetValueOrDefault();
+            Assert.IsNotNull(rowId);
+            updateRequest.RowIds = new List<long> { rowId };
             updateRequest.ColumnIds = new List<long> { addedColumn2.Id.Value };
             updateRequest.IncludeAttachments = false;
             updateRequest.IncludeDiscussions = false;
@@ -269,20 +319,31 @@ namespace integration_test_sdk_net80
         private void TestSortSheet()
         {
             Sheet sheet = CreateSheet();
+            Assert.IsNotNull(sheet?.Id);
 
             SortSpecifier specifier = new SortSpecifier();
             SortCriterion criterion = new SortCriterion();
-            criterion.ColumnId = sheet.Columns[1].Id.Value;
+            var columnId = sheet?.Columns[1]?.Id.GetValueOrDefault();
+            Assert.IsNotNull(columnId);
+            Assert.IsNotNull(sheet?.Id);
+            var sheetId = sheet.Id.Value;
+            criterion.ColumnId = columnId.Value;
             criterion.Direction = SortDirection.DESCENDING;
             specifier.SortCriteria = new SortCriterion[] { criterion };
-            sheet = smartsheet.SheetResources.SortSheet(sheet.Id.Value, specifier);
+            Assert.IsNotNull(smartsheet);
+            sheet = smartsheet.SheetResources.SortSheet(sheetId, specifier);
             Assert.AreEqual(sheet.Rows[0].Cells[1].DisplayValue, "C");
 
-            DeleteSheet(sheet.Id.Value);
+            DeleteSheet(sheetId);
         }
 
         private void TestDeleteSheet()
         {
+            Assert.IsNotNull(newSheetHome?.Id);
+            Assert.IsNotNull(newSheetTemplate?.Id);
+            Assert.IsNotNull(workspace?.Id);
+            Assert.IsNotNull(folder?.Id);
+            Assert.IsNotNull(smartsheet);
             smartsheet.SheetResources.DeleteSheet(newSheetHome.Id.Value);
             smartsheet.SheetResources.DeleteSheet(newSheetTemplate.Id.Value);
             DeleteWorkspace(workspace.Id.Value);

--- a/integration-test-sdk-net80/SheetResourcesUpdateRequestTest.cs
+++ b/integration-test-sdk-net80/SheetResourcesUpdateRequestTest.cs
@@ -14,7 +14,9 @@ namespace integration_test_sdk_net80
             long sheetId = CreateSheet(smartsheet);
 
             PaginatedResult<Column> columnsResult = smartsheet.SheetResources.ColumnResources.ListColumns(sheetId);
-            long columnId = columnsResult.Data[0].Id.Value;
+            var columnsResultDataId = columnsResult.Data[0].Id;
+            Assert.IsNotNull(columnsResultDataId);
+            long columnId = columnsResultDataId.Value;
 
             Cell[] cellsToAdd = new Cell[] { new Cell.AddCellBuilder(columnId, true).SetValue("hello").SetStrict(false).Build() };
 
@@ -58,7 +60,9 @@ namespace integration_test_sdk_net80
 
         private static void CopyRowToCreatedSheet(SmartsheetClient smartsheet, long sheetId, long rowId)
         {
-            long tempSheetId = smartsheet.SheetResources.CreateSheet(new Sheet.CreateSheetBuilder("tempSheet", new Column[] { new Column.CreateSheetColumnBuilder("col1", true, ColumnType.TEXT_NUMBER).Build() }).Build()).Id.Value;
+            var tempSheet = smartsheet.SheetResources.CreateSheet(new Sheet.CreateSheetBuilder("tempSheet", new Column[] { new Column.CreateSheetColumnBuilder("col1", true, ColumnType.TEXT_NUMBER).Build() }).Build()).Id;
+            Assert.IsNotNull(tempSheet);
+            long tempSheetId = tempSheet.Value;
             CopyOrMoveRowDestination destination = new CopyOrMoveRowDestination { SheetId = tempSheetId };
             CopyOrMoveRowDirective directive = new CopyOrMoveRowDirective { RowIds = new long[] { rowId }, To = destination };
             CopyOrMoveRowResult result = smartsheet.SheetResources.RowResources.CopyRowsToAnotherSheet(sheetId, directive, new CopyRowInclusion[] { CopyRowInclusion.CHILDREN }, false);
@@ -75,6 +79,7 @@ namespace integration_test_sdk_net80
             IList<long> rowIds = new List<long>();
             foreach (Row row in rows)
             {
+                Assert.IsNotNull(row.Id);
                 rowIds.Add(row.Id.Value);
             }
             return rowIds;
@@ -90,6 +95,7 @@ namespace integration_test_sdk_net80
             Sheet createdSheet = smartsheet.SheetResources.CreateSheet(new Sheet.CreateSheetBuilder("new sheet", columnsToCreate).Build());
             Assert.IsTrue(createdSheet.Columns.Count == 3);
             Assert.IsTrue(createdSheet.Columns[1].Title == "col 2");
+            Assert.IsNotNull(createdSheet.Id);
             return createdSheet.Id.Value;
         }
     }

--- a/integration-test-sdk-net80/SheetSummaryResourcesTest.cs
+++ b/integration-test-sdk-net80/SheetSummaryResourcesTest.cs
@@ -5,8 +5,8 @@ namespace integration_test_sdk_net80
     [TestClass]
     public class SheetSummaryResourcesTest : TestResources
     {
-        private Sheet sheet;
-        private IList<SummaryField> asf;
+        private Sheet? sheet;
+        private IList<SummaryField>? asf;
 
         [TestInitialize]
         public void TestInitialize()
@@ -18,6 +18,7 @@ namespace integration_test_sdk_net80
         [TestCleanup]
         public void TestTeardown()
         {
+            Assert.IsNotNull(sheet?.Id);
             DeleteSheet(sheet.Id.Value);
         }
 
@@ -48,6 +49,8 @@ namespace integration_test_sdk_net80
             sf1.Type = ColumnType.CHECKBOX;
             sf1.ObjectValue = new BooleanObjectValue(false);
 
+            Assert.IsNotNull(sheet?.Id);
+            Assert.IsNotNull(smartsheet);
             asf = smartsheet.SheetResources.SummaryResources.AddSheetSummaryFields(sheet.Id.Value,
                 new List<SummaryField> { sf, sf1 }, true);
 
@@ -56,6 +59,8 @@ namespace integration_test_sdk_net80
 
         private void TestGetSheetSummary()
         {
+            Assert.IsNotNull(sheet?.Id);
+            Assert.IsNotNull(smartsheet);
             SheetSummary sheetSummary = smartsheet.SheetResources.SummaryResources.GetSheetSummary(sheet.Id.Value,
                 new List<SummaryFieldInclusion> { SummaryFieldInclusion.FORMAT, SummaryFieldInclusion.WRITER_INFO },
                 new List<SummaryFieldExclusion> { SummaryFieldExclusion.DISPLAY_VALUE });
@@ -78,6 +83,8 @@ namespace integration_test_sdk_net80
             sf1.Type = ColumnType.TEXT_NUMBER;
             sf1.ObjectValue = new StringObjectValue("Sammy Smart");
 
+            Assert.IsNotNull(sheet?.Id);
+            Assert.IsNotNull(smartsheet);
             BulkItemResult<SummaryField> asf = smartsheet.SheetResources.SummaryResources.AddSheetSummaryFieldsAllowPartialSuccess(
                 sheet.Id.Value,  new List<SummaryField> { sf, sf1 });
 
@@ -86,6 +93,8 @@ namespace integration_test_sdk_net80
 
         private void TestGetSheetSummaryFields()
         {
+            Assert.IsNotNull(sheet?.Id);
+            Assert.IsNotNull(smartsheet);
             PaginatedResult<SummaryField> fields = smartsheet.SheetResources.SummaryResources.GetSheetSummaryFields(sheet.Id.Value,
                 new List<SummaryFieldInclusion> { SummaryFieldInclusion.WRITER_INFO },
                 new List<SummaryFieldExclusion> { SummaryFieldExclusion.DISPLAY_VALUE });
@@ -98,6 +107,7 @@ namespace integration_test_sdk_net80
         private void TestUpdateSheetSummaryFields()
         {
             SummaryField sf = new SummaryField();
+            Assert.IsNotNull(asf);
             sf.Id = asf[0].Id;
             sf.Title = "Hellooo World!";
 
@@ -105,6 +115,8 @@ namespace integration_test_sdk_net80
             sf1.Id = asf[1].Id;
             sf1.Title = "Eeek!";
 
+            Assert.IsNotNull(sheet?.Id);
+            Assert.IsNotNull(smartsheet);
             IList<SummaryField> usf = smartsheet.SheetResources.SummaryResources.UpdateSheetSummaryFields(sheet.Id.Value,
                 new List<SummaryField> { sf, sf1 });
         }
@@ -112,6 +124,7 @@ namespace integration_test_sdk_net80
         private void TestUpdateSheetSummaryFieldsWithPartialSuccess()
         {
             SummaryField sf = new SummaryField();
+            Assert.IsNotNull(asf);
             sf.Id = asf[0].Id;
             sf.Title = "Hello World!";
 
@@ -119,6 +132,8 @@ namespace integration_test_sdk_net80
             sf1.Id = 123;
             sf1.Title = "Eeek!";
 
+            Assert.IsNotNull(sheet?.Id);
+            Assert.IsNotNull(smartsheet);
             BulkItemResult<SummaryField> usf = smartsheet.SheetResources.SummaryResources.UpdateSheetSummaryFieldsAllowPartialSuccess(sheet.Id.Value,
                 new List<SummaryField> { sf, sf1 }, true);
 
@@ -127,15 +142,25 @@ namespace integration_test_sdk_net80
 
         private void TestAddSheetSummaryFieldImage()
         {
+            Assert.IsNotNull(sheet?.Id);
+            Assert.IsNotNull(asf);
+            var addSheetSummaryField = asf[0].Id;
+            Assert.IsNotNull(addSheetSummaryField);
+            Assert.IsNotNull(smartsheet);
             SummaryField summaryField = smartsheet.SheetResources.SummaryResources.AddSheetSummaryFieldImage(sheet.Id.Value,
-                asf[0].Id.Value, "D:\\Smartsheet\\vHepGiJaeL6GPOX3wAx8yaxD75ym5eAbk0GB-MSz0gc.png", null, "alt text");
+                addSheetSummaryField.Value, "D:\\Smartsheet\\vHepGiJaeL6GPOX3wAx8yaxD75ym5eAbk0GB-MSz0gc.png", null, "alt text");
             Assert.IsInstanceOfType(summaryField.Image, typeof(Image));
         }
 
         private void TestDeleteSheetSummaryFields()
         {
+            Assert.IsNotNull(sheet?.Id);
+            Assert.IsNotNull(asf);
+            var addSheetSummaryField = asf[0].Id;
+            Assert.IsNotNull(addSheetSummaryField);
+            Assert.IsNotNull(smartsheet);
             IList<long> delIds = smartsheet.SheetResources.SummaryResources.DeleteSheetSummaryFields(sheet.Id.Value,
-                new List<long> { asf[0].Id.Value, 123L }, true);
+                new List<long> { addSheetSummaryField.Value, 123L }, true);
             Assert.AreEqual(delIds.Count, 1);
         }
     }

--- a/integration-test-sdk-net80/TestResources.cs
+++ b/integration-test-sdk-net80/TestResources.cs
@@ -5,7 +5,7 @@ namespace integration_test_sdk_net80
 {
     public class TestResources
     {
-        protected SmartsheetClient smartsheet;
+        protected SmartsheetClient? smartsheet;
 
         public SmartsheetClient CreateClient()
         {
@@ -26,10 +26,14 @@ namespace integration_test_sdk_net80
 
         public Sheet CreateSheet()
         {
+            Assert.IsNotNull(smartsheet);
             Sheet sheet = smartsheet.SheetResources.CreateSheet(CreateSheetObject());
-            Cell cellA = new Cell.AddCellBuilder(sheet.Columns[1].Id.Value, null).SetValue("A").SetStrict(false).Build();
-            Cell cellB = new Cell.AddCellBuilder(sheet.Columns[1].Id.Value, null).SetValue("B").SetStrict(false).Build();
-            Cell cellC = new Cell.AddCellBuilder(sheet.Columns[1].Id.Value, null).SetValue("C").SetStrict(false).Build();
+            Assert.IsNotNull(sheet.Id);
+            var sheetColumns = sheet.Columns[1].Id;
+            Assert.IsNotNull(sheetColumns);
+            Cell cellA = new Cell.AddCellBuilder(sheetColumns.Value, null).SetValue("A").SetStrict(false).Build();
+            Cell cellB = new Cell.AddCellBuilder(sheetColumns.Value, null).SetValue("B").SetStrict(false).Build();
+            Cell cellC = new Cell.AddCellBuilder(sheetColumns.Value, null).SetValue("C").SetStrict(false).Build();
             Row rowA = new Row.AddRowBuilder(true, null, null, null, null).SetCells(new Cell[] { cellA }).Build();
             Row rowB = new Row.AddRowBuilder(true, null, null, null, null).SetCells(new Cell[] { cellB }).Build();
             Row rowC = new Row.AddRowBuilder(true, null, null, null, null).SetCells(new Cell[] { cellC }).Build();
@@ -40,28 +44,33 @@ namespace integration_test_sdk_net80
         public Folder CreateFolderHome()
         {
             Folder folder = new Folder.CreateFolderBuilder("CSharp SDK Test").Build();
+            Assert.IsNotNull(smartsheet);
             Folder newFolderHome = smartsheet.HomeResources.FolderResources.CreateFolder(folder);
             return newFolderHome;
         }
 
         public Workspace CreateWorkspace(string name)
         {
+            Assert.IsNotNull(smartsheet);
             Workspace newWorkspace = smartsheet.WorkspaceResources.CreateWorkspace(new Workspace.CreateWorkspaceBuilder(name).Build());
             return newWorkspace;
         }
 
         public void DeleteFolder(long folderId)
         {
+            Assert.IsNotNull(smartsheet);
             smartsheet.FolderResources.DeleteFolder(folderId);
         }
 
         public void DeleteSheet(long sheetId)
         {
+            Assert.IsNotNull(smartsheet);
             smartsheet.SheetResources.DeleteSheet(sheetId);
         }
 
         public void DeleteWorkspace(long workspaceId)
         {
+            Assert.IsNotNull(smartsheet);
             smartsheet.WorkspaceResources.DeleteWorkspace(workspaceId);
         }
     }

--- a/integration-test-sdk-net80/UserResourcesTest.cs
+++ b/integration-test-sdk-net80/UserResourcesTest.cs
@@ -6,7 +6,7 @@ namespace integration_test_sdk_net80
     public class UserResourcesTest : TestResources
     {
         private static string email = "test+email@invalidsmartsheet.com";
-        User user;
+        User? user;
 
         [TestInitialize]
         public void SetUp()
@@ -19,6 +19,7 @@ namespace integration_test_sdk_net80
             {
                 if (tmpUser.Email == email)
                 {
+                    Assert.IsNotNull(tmpUser.Id);
                     smartsheet.UserResources.RemoveUser((long)tmpUser.Id, removeFromSharing: true);
                     break;
                 }
@@ -28,6 +29,7 @@ namespace integration_test_sdk_net80
         [TestMethod]
         public void GetMe()
         {
+            Assert.IsNotNull(smartsheet);
             UserProfile userMe = smartsheet.UserResources.GetCurrentUser();
             Assert.IsTrue(userMe.Email != null);
         }
@@ -50,26 +52,36 @@ namespace integration_test_sdk_net80
             User _user = new User.AddUserBuilder(email, true, true).Build();
             _user.FirstName = "Mister";
             _user.LastName = "CSharp";
+            Assert.IsNotNull(smartsheet);
             user = smartsheet.UserResources.AddUser(_user, true, true);
+            Assert.IsNotNull(user.Admin);
             Assert.IsTrue(user.Admin.Value);
+            Assert.IsNotNull(user.LicensedSheetCreator);
             Assert.IsTrue(user.LicensedSheetCreator.Value);
         }
 
         private void GetUser()
         {
+            Assert.IsNotNull(user?.Id);
+            Assert.IsNotNull(smartsheet);
             smartsheet.UserResources.GetUser(user.Id.Value);
         }
 
         private void UpdateUser()
         {
+            Assert.IsNotNull(user?.Id);
             User _user = new User.UpdateUserBuilder(user.Id.Value, false, false).Build();
+            Assert.IsNotNull(smartsheet);
             user = smartsheet.UserResources.UpdateUser(_user);
+            Assert.IsNotNull(user.Admin);
             Assert.IsFalse(user.Admin.Value);
+            Assert.IsNotNull(user.LicensedSheetCreator);
             Assert.IsFalse(user.LicensedSheetCreator.Value);
         }
 
         private void ListOneUser()
         {
+            Assert.IsNotNull(smartsheet);
             PaginatedResult<User> users = smartsheet.UserResources.ListUsers(new String[] { "test+email@invalidsmartsheet.com" }, null);
             Assert.AreEqual(1, users.TotalCount);
             Assert.AreEqual(users.Data[0].Email, "test+email@invalidsmartsheet.com");
@@ -77,6 +89,7 @@ namespace integration_test_sdk_net80
 
         private void ListAllUsers()
         {
+            Assert.IsNotNull(smartsheet);
             PaginatedResult<User> users = smartsheet.UserResources.ListUsers(new String[] { "test+email@invalidsmartsheet.com" }, null);
             // current user + added user
             Assert.IsTrue(users.Data.Count >= 2);
@@ -84,32 +97,40 @@ namespace integration_test_sdk_net80
 
         private void RemoveUser()
         {
+            Assert.IsNotNull(user?.Id);
+            Assert.IsNotNull(smartsheet);
             smartsheet.UserResources.RemoveUser(user.Id.Value);
         }
 
         [TestMethod]
         public void TestAlternateEmail()
         {
+            Assert.IsNotNull(smartsheet);
             UserProfile me = smartsheet.UserResources.GetCurrentUser();
 
             AlternateEmail altEmail1 = new AlternateEmail.AlternateEmailBuilder("test+altemail2@invalidsmartsheet.com").Build();
             AlternateEmail altEmail2 = new AlternateEmail.AlternateEmailBuilder("test+altemail3@invalidsmartsheet.com").Build();
+            Assert.IsNotNull(me.Id);
             smartsheet.UserResources.AddAlternateEmail(me.Id.Value, new AlternateEmail[] { altEmail1, altEmail2 });
 
             PaginatedResult<AlternateEmail> altEmails = smartsheet.UserResources.ListAlternateEmails(me.Id.Value);
             Assert.IsTrue(altEmails.Data.Count >= 2);
 
-            AlternateEmail altEmail = smartsheet.UserResources.GetAlternateEmail(me.Id.Value, altEmails.Data[0].Id.Value);
+            var altEmailsData = altEmails.Data[0].Id;
+            Assert.IsNotNull(altEmailsData);
+            AlternateEmail altEmail = smartsheet.UserResources.GetAlternateEmail(me.Id.Value, altEmailsData.Value);
             Assert.AreEqual(altEmail.Email, "test+altemail2@invalidsmartsheet.com");
 
-            smartsheet.UserResources.DeleteAlternateEmail(me.Id.Value, altEmails.Data[0].Id.Value);
-            smartsheet.UserResources.DeleteAlternateEmail(me.Id.Value, altEmails.Data[1].Id.Value);
+            smartsheet.UserResources.DeleteAlternateEmail(me.Id.Value, altEmailsData.Value);
+            smartsheet.UserResources.DeleteAlternateEmail(me.Id.Value, altEmailsData.Value);
         }
 
         [TestMethod]
         public void AddProfileImage()
         {
+            Assert.IsNotNull(smartsheet);
             UserProfile me = smartsheet.UserResources.GetCurrentUser();
+            Assert.IsNotNull(me.Id);
             smartsheet.UserResources.AddProfileImage(me.Id.Value, "../../../../integration-test-sdk-net80/profileimage.png", "image/png");
             me = smartsheet.UserResources.GetCurrentUser();
             Assert.IsNotNull(me.ProfileImage.ImageId);

--- a/integration-test-sdk-net80/WorkspaceResourcesCopyTest.cs
+++ b/integration-test-sdk-net80/WorkspaceResourcesCopyTest.cs
@@ -20,6 +20,7 @@ namespace integration_test_sdk_net80
             // Folder2-----Workspace1Copy
 
             Workspace workspace = smartsheet.WorkspaceResources.CreateWorkspace(new Workspace.CreateWorkspaceBuilder("Workspace1").Build());
+            Assert.IsNotNull(workspace.Id);
             long workspaceId = workspace.Id.Value;
 
             ContainerDestination destination = new ContainerDestination
@@ -30,6 +31,7 @@ namespace integration_test_sdk_net80
 
             Assert.IsTrue(newCopiedWorkspace.Name == "Workspace1Copy");
 
+            Assert.IsNotNull(newCopiedWorkspace.Id);
             long copiedWorkspaceId = newCopiedWorkspace.Id.Value;
 
             Workspace copiedWorkspace = smartsheet.WorkspaceResources.GetWorkspace(copiedWorkspaceId);
@@ -56,12 +58,14 @@ namespace integration_test_sdk_net80
         private static long CreateWorkspaceInFolder(SmartsheetClient smartsheet, long folderId, string folderName)
         {
             Folder createdFolderInFolder = smartsheet.WorkspaceResources.FolderResources.CreateFolder(folderId, new Folder.CreateFolderBuilder(folderName).Build());
+            Assert.IsNotNull(createdFolderInFolder.Id);
             return createdFolderInFolder.Id.Value;
         }
 
         private static long CreateFolderInHome(SmartsheetClient smartsheet, string folderName)
         {
             Folder createdFolderInHome = smartsheet.HomeResources.FolderResources.CreateFolder(new Folder.CreateFolderBuilder(folderName).Build());
+            Assert.IsNotNull(createdFolderInHome.Id);
             return createdFolderInHome.Id.Value;
         }
     }

--- a/integration-test-sdk-net80/WorkspaceResourcesTest.cs
+++ b/integration-test-sdk-net80/WorkspaceResourcesTest.cs
@@ -43,10 +43,11 @@ namespace integration_test_sdk_net80
             bool contains = false;
             foreach (Workspace ws in workspaceResult.Data)
             {
+                Assert.IsNotNull(ws.Id);
                 if (ws.Id.Value == workspaceId)
                 {
                     contains = true;
-                    break;    
+                    break;
                 }
             }
             Assert.IsTrue(contains);
@@ -54,6 +55,7 @@ namespace integration_test_sdk_net80
         private static void GetWorkspace(SmartsheetClient smartsheet, long workspaceId)
         {
             Workspace workspace = smartsheet.WorkspaceResources.GetWorkspace(workspaceId, true, new WorkspaceInclusion[] { WorkspaceInclusion.SOURCE });
+            Assert.IsNotNull(workspace.Id);
             Assert.IsTrue(workspace.Id.Value == workspaceId);
         }
 
@@ -72,6 +74,7 @@ namespace integration_test_sdk_net80
 
             Workspace createdWorkspace = smartsheet.WorkspaceResources.CreateWorkspace(workspace);
             Assert.IsTrue(createdWorkspace.Name == "workspace");
+            Assert.IsNotNull(createdWorkspace.Id);
             return createdWorkspace.Id.Value;
         }
     }

--- a/mock-api-test-sdk-net80/AutomationRulesTest.cs
+++ b/mock-api-test-sdk-net80/AutomationRulesTest.cs
@@ -12,6 +12,8 @@ namespace mock_api_test_sdk_net80
         {
             SmartsheetClient ss = HelperFunctions.SetupClient("List Automation Rules");
             PaginatedResult<AutomationRule> automationRules = ss.SheetResources.AutomationRuleResources.ListAutomationRules(324);
+
+            Assert.IsNotNull(automationRules.TotalCount);
             Assert.AreEqual(2, (long)automationRules.TotalCount);
         }
 
@@ -20,6 +22,7 @@ namespace mock_api_test_sdk_net80
         {
             SmartsheetClient ss = HelperFunctions.SetupClient("Get Automation Rule");
             AutomationRule automationRule = ss.SheetResources.AutomationRuleResources.GetAutomationRule(324, 284);
+            Assert.IsNotNull(automationRule.Id);
             Assert.AreEqual(284, (long)automationRule.Id);
         }
 

--- a/mock-api-test-sdk-net80/HelperFunctions.cs
+++ b/mock-api-test-sdk-net80/HelperFunctions.cs
@@ -37,7 +37,9 @@ namespace mock_api_test_sdk_net80
             }
             catch (AssertFailedException ex)
             {
+#pragma warning disable CA2200 // Rethrow to preserve stack details
                 throw ex;
+#pragma warning restore CA2200 // Rethrow to preserve stack details
             }
             catch (Exception ex)
             {

--- a/mock-api-test-sdk-net80/RowTests.cs
+++ b/mock-api-test-sdk-net80/RowTests.cs
@@ -45,9 +45,10 @@ namespace mock_api_test_sdk_net80
             // Update rows in sheet
             IList<Row> addedRows = ss.SheetResources.RowResources.AddRows(1, new Row[] { rowA, rowB });
 
-            Row row = addedRows.Where(r => r.Id == 10).FirstOrDefault();
-            Cell cell = row.Cells.Where(c => c.Value.Equals("Apple")).FirstOrDefault();
+            Row? row = addedRows.FirstOrDefault(r => r.Id == 10);
+            Cell? cell = row?.Cells.FirstOrDefault(c => c.Value.Equals("Apple"));
 
+            Assert.IsNotNull(cell);
             Assert.AreEqual(101, cell.ColumnId);
         }
 
@@ -89,9 +90,9 @@ namespace mock_api_test_sdk_net80
             // Update rows in sheet
             IList<Row> addedRows = ss.SheetResources.RowResources.AddRows(1, new Row[] { rowA, rowB });
 
-            Row row = addedRows.Where(r => r.Id == 10).FirstOrDefault();
-            Cell cell = row.Cells.Where(c => Convert.ToInt32(c.Value) == 100).FirstOrDefault();
-
+            Row? row = addedRows.FirstOrDefault(r => r.Id == 10);
+            Cell? cell = row?.Cells.FirstOrDefault(c => Convert.ToInt32(c.Value) == 100);
+            Assert.IsNotNull(cell);
             Assert.AreEqual(101, cell.ColumnId);
         }
 
@@ -133,9 +134,10 @@ namespace mock_api_test_sdk_net80
             // Update rows in sheet
             IList<Row> addedRows = ss.SheetResources.RowResources.AddRows(1, new Row[] { rowA, rowB });
 
-            Row row = addedRows.Where(r => r.Id == 10).FirstOrDefault();
-            Cell cell = row.Cells.Where(c => c.Value.Equals(true)).FirstOrDefault();
+            Row? row = addedRows.FirstOrDefault(r => r.Id == 10);
+            Cell? cell = row?.Cells.FirstOrDefault(c => c.Value.Equals(true));
 
+            Assert.IsNotNull(cell);
             Assert.AreEqual(101, cell.ColumnId);
         }
 
@@ -162,8 +164,8 @@ namespace mock_api_test_sdk_net80
 
             IList<Row> addedRows = ss.SheetResources.RowResources.AddRows(1, new Row[] { rowA });
 
-            Cell cell = addedRows[0].Cells.Where(c => c.Formula.Equals("=SUM([Column2]3, [Column2]3, [Column2]4)")).FirstOrDefault();
-
+            Cell? cell = addedRows[0].Cells.FirstOrDefault(c => c.Formula.Equals("=SUM([Column2]3, [Column2]3, [Column2]4)"));
+            Assert.IsNotNull(cell);
             Assert.AreEqual(102, cell.ColumnId);
         }
 
@@ -195,7 +197,8 @@ namespace mock_api_test_sdk_net80
 
             IList<Row> addedRows = ss.SheetResources.RowResources.AddRows(1, new Row[] { rowA });
 
-            Cell cell = addedRows[0].Cells.Where(c => c.Value.Equals("Google")).FirstOrDefault();
+            Cell? cell = addedRows[0].Cells.FirstOrDefault(c => c.Value.Equals("Google"));
+            Assert.IsNotNull(cell);
             Hyperlink link = cell.Hyperlink;
 
             Assert.AreEqual(101, cell.ColumnId);
@@ -229,8 +232,9 @@ namespace mock_api_test_sdk_net80
             };
 
             IList<Row> addedRows = ss.SheetResources.RowResources.AddRows(1, new Row[] { rowA });
-
-            Cell cell = addedRows[0].Cells.Where(c => c.Value.Equals("Sheet3")).FirstOrDefault();
+            var cellsValue = addedRows[0].Cells;
+            Cell? cell = cellsValue.FirstOrDefault(c => c.Value.Equals("Sheet3"));
+            Assert.IsNotNull(cell);
             Hyperlink link = cell.Hyperlink;
 
             Assert.AreEqual(102, cell.ColumnId);
@@ -265,7 +269,8 @@ namespace mock_api_test_sdk_net80
 
             IList<Row> addedRows = ss.SheetResources.RowResources.AddRows(1, new Row[] { rowA });
 
-            Cell cell = addedRows[0].Cells.Where(c => c.Value.Equals("Report8")).FirstOrDefault();
+            Cell? cell = addedRows[0].Cells.FirstOrDefault(c => c.Value.Equals("Report8"));
+            Assert.IsNotNull(cell);
             Hyperlink link = cell.Hyperlink;
 
             Assert.AreEqual(102, cell.ColumnId);
@@ -393,10 +398,11 @@ namespace mock_api_test_sdk_net80
             // Update rows in sheet
             IList<Row> addedRows = ss.SheetResources.RowResources.AddRows(1, new Row[] { rowA });
 
-            Row row = addedRows.Where(r => r.Id == 10).FirstOrDefault();
-            Cell cell = row.Cells.Where(c => c.Value.Equals("Apple")).FirstOrDefault();
+            Row? row = addedRows.FirstOrDefault(r => r.Id == 10);
+            Cell? cell = row?.Cells.FirstOrDefault(c => c.Value.Equals("Apple"));
 
-            Assert.AreEqual(1, row.RowNumber);
+            Assert.AreEqual(1, row?.RowNumber);
+            Assert.IsNotNull(cell);
             Assert.AreEqual(101, cell.ColumnId);
         }
 
@@ -424,10 +430,11 @@ namespace mock_api_test_sdk_net80
             // Update rows in sheet
             IList<Row> addedRows = ss.SheetResources.RowResources.AddRows(1, new Row[] { rowA });
 
-            Row row = addedRows.Where(r => r.Id == 10).FirstOrDefault();
-            Cell cell = row.Cells.Where(c => c.Value.Equals("Apple")).FirstOrDefault();
+            Row? row = addedRows.FirstOrDefault(r => r.Id == 10);
+            Cell? cell = row?.Cells.FirstOrDefault(c => c.Value.Equals("Apple"));
 
-            Assert.AreEqual(100, row.RowNumber);
+            Assert.AreEqual(100, row?.RowNumber);
+            Assert.IsNotNull(cell);
             Assert.AreEqual(101, cell.ColumnId);
         }
 
@@ -471,9 +478,9 @@ namespace mock_api_test_sdk_net80
             // Update rows in sheet
             IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA, rowB });
 
-            Row row = updatedRows.Where(r => r.Id == 10).FirstOrDefault();
-            Cell cell = row.Cells.Where(c => c.Value.Equals("Apple")).FirstOrDefault();
-
+            Row? row = updatedRows.Where(r => r.Id == 10).FirstOrDefault();
+            Cell? cell = row?.Cells.Where(c => c.Value.Equals("Apple")).FirstOrDefault();
+            Assert.IsNotNull(cell);
             Assert.AreEqual(101, cell.ColumnId);
         }
 
@@ -515,11 +522,10 @@ namespace mock_api_test_sdk_net80
             };
 
             // Update rows in sheet
-            IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA, rowB });
-
-            Row row = updatedRows.Where(r => r.Id == 10).FirstOrDefault();
-            Cell cell = row.Cells.Where(c => Convert.ToInt32(c.Value) == 100).FirstOrDefault();
-
+            IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, [rowA, rowB]);
+            Row? row = updatedRows.FirstOrDefault(r => r.Id == 10);
+            Cell? cell = row?.Cells.FirstOrDefault(c => Convert.ToInt32(c.Value) == 100);
+            Assert.IsNotNull(cell);
             Assert.AreEqual(101, cell.ColumnId);
         }
 
@@ -563,9 +569,9 @@ namespace mock_api_test_sdk_net80
             // Update rows in sheet
             IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA, rowB });
 
-            Row row = updatedRows.Where(r => r.Id == 10).FirstOrDefault();
-            Cell cell = row.Cells.Where(c => c.Value.Equals(true)).FirstOrDefault();
-
+            Row? row = updatedRows.FirstOrDefault(r => r.Id == 10);
+            Cell? cell = row?.Cells.FirstOrDefault(c => c.Value.Equals(true));
+            Assert.IsNotNull(cell);
             Assert.AreEqual(101, cell.ColumnId);
         }
 
@@ -592,8 +598,8 @@ namespace mock_api_test_sdk_net80
 
             IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
 
-            Cell cell = updatedRows[0].Cells.Where(c => c.Formula.Equals("=SUM([Column2]3, [Column2]3, [Column2]4)")).FirstOrDefault();
-
+            Cell? cell = updatedRows[0].Cells.Where(c => c.Formula.Equals("=SUM([Column2]3, [Column2]3, [Column2]4)")).FirstOrDefault();
+            Assert.IsNotNull(cell);
             Assert.AreEqual(102, cell.ColumnId);
         }
 
@@ -626,7 +632,8 @@ namespace mock_api_test_sdk_net80
 
             IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
 
-            Cell cell = updatedRows[0].Cells.Where(c => c.Value.Equals("Google")).FirstOrDefault();
+            Cell? cell = updatedRows[0].Cells.Where(c => c.Value.Equals("Google")).FirstOrDefault();
+            Assert.IsNotNull(cell);
             Hyperlink link = cell.Hyperlink;
 
             Assert.AreEqual(101, cell.ColumnId);
@@ -661,8 +668,10 @@ namespace mock_api_test_sdk_net80
             };
 
             IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
-
-            Cell cell = updatedRows[0].Cells.Where(c => c.Value.Equals("Sheet3")).FirstOrDefault();
+            var cells = updatedRows[0].Cells;
+            Assert.IsNotNull(cells);
+            Cell? cell = cells.FirstOrDefault(c => c.Value.Equals("Sheet3"));
+            Assert.IsNotNull(cell);
             Hyperlink link = cell.Hyperlink;
 
             Assert.AreEqual(102, cell.ColumnId);
@@ -698,7 +707,8 @@ namespace mock_api_test_sdk_net80
 
             IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
 
-            Cell cell = updatedRows[0].Cells.Where(c => c.Value.Equals("Report8")).FirstOrDefault();
+            Cell? cell = updatedRows[0].Cells.FirstOrDefault(c => c.Value.Equals("Report8"));
+            Assert.IsNotNull(cell);
             Hyperlink link = cell.Hyperlink;
 
             Assert.AreEqual(102, cell.ColumnId);

--- a/mock-api-test-sdk-net80/SightsTest.cs
+++ b/mock-api-test-sdk-net80/SightsTest.cs
@@ -12,6 +12,7 @@ namespace mock_api_test_sdk_net80
         {
             SmartsheetClient ss = HelperFunctions.SetupClient("List Sights");
             PaginatedResult<Sight> sights = ss.SightResources.ListSights();
+            Assert.IsNotNull(sights?.TotalCount);
             Assert.AreEqual(6, (long)sights.TotalCount);
         }
 
@@ -20,6 +21,7 @@ namespace mock_api_test_sdk_net80
         {
             SmartsheetClient ss = HelperFunctions.SetupClient("Get Sight");
             Sight sight = ss.SightResources.GetSight(52);
+            Assert.IsNotNull(sight?.Id);
             Assert.AreEqual(52, (long)sight.Id);
         }
 
@@ -60,6 +62,7 @@ namespace mock_api_test_sdk_net80
         {
             SmartsheetClient ss = HelperFunctions.SetupClient("Get Sight Publish Status");
             SightPublish publish = ss.SightResources.GetPublishStatus(812);
+            Assert.IsNotNull(publish.ReadOnlyFullEnabled);
             Assert.IsTrue(publish.ReadOnlyFullEnabled.Value);
         }
 


### PR DESCRIPTION
Previously on mainline 
```
git clean -xfd && dotnet build
...
   301 Warning(s)
    0 Error(s)
```

now 
```
git clean -xfd && dotnet build
...
    59 Warning(s)
    0 Error(s)
 ```
 
 this MR also bumps the vulnerable version of the restsharp sdk