### PR TITLE
Deprecating favorite field in models and adding isFavorite endpoint

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -80,7 +80,7 @@ A more complete example can be found in the Integration test file, `PassthroughR
 ## Testing
 Integration tests:
 1. Your environment must contain a variable named SMARTSHEET_ACCESS_TOKEN containing an api access token in order to proceed with the tests.
-2. Run the tests within the from within Visual Studio.
+2. Run the tests from within Visual Studio.
 
 Mock API tests:
 1. Clone the [Smartsheet sdk tests](https://github.com/smartsheet-platform/smartsheet-sdk-tests) repo and follow the instructions from the readme to start the mock server.

--- a/integration-test-sdk-net80/FavoriteResourcesTest.cs
+++ b/integration-test-sdk-net80/FavoriteResourcesTest.cs
@@ -21,6 +21,7 @@ namespace integration_test_sdk_net80
             long workspaceId;
 
             AddFavorites(smartsheet, out sheetId, out folderId, out workspaceId);
+            IsFavorite(smartsheet, sheetId);
 
             RemoveAndListFavorites(smartsheet, sheetId, folderId, workspaceId);
 
@@ -60,6 +61,13 @@ namespace integration_test_sdk_net80
 
             IList<Favorite> favsAdded = smartsheet.FavoriteResources.AddFavorites(favs);
             Assert.IsTrue(favsAdded.Count == 3);
+        }
+
+        private static void IsFavorite(SmartsheetClient smartsheet, long sheetId)
+        {
+            Favorite fav = smartsheet.FavoriteResources.IsFavorite(ObjectType.SHEET, sheetId);
+            Assert.IsTrue(fav.ObjectId == sheetId);
+            Assert.IsTrue(fav.Type == ObjectType.SHEET);
         }
 
         private static void RemoveAllFavoritesBeforeRunningTest(SmartsheetClient smartsheet)

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/FavoriteResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/FavoriteResources.cs
@@ -72,7 +72,7 @@ namespace Smartsheet.Api
         /// <returns>A single Favorite object (note that a 404 status will be returned if the object is not currently favorited).</returns>
         /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
         /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
-        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
         /// <exception cref="ResourceNotFoundException"> if the resource cannot be found or the object is not a favorite</exception>
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/FavoriteResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/FavoriteResources.cs
@@ -64,6 +64,21 @@ namespace Smartsheet.Api
         PaginatedResult<Favorite> ListFavorites(PaginationParameters? paging = null);
 
         /// <summary>
+        /// <para>Gets a single Favorite item by type and objectId. If the object is not a favorite, a 404 status will be returned.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /favorites/{favoriteType}/{objectId}</para>
+        /// </summary>
+        /// <param name="type">(required): the object type</param>
+        /// <param name="objectId">(required): object ID representing a single favorited item.</param>
+        /// <returns>A single Favorite object (note that a 404 status will be returned if the object is not currently favorited).</returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found or the object is not a favorite</exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Favorite IsFavorite(ObjectType type, long objectId);
+
+        /// <summary>
         /// <para>Removes one or multiple objects from the user’s list of Favorite items.</para>
         /// <para>It mirrors to the following Smartsheet REST API methods: 
         /// <list type="bullet">

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/FavoriteResourcesImpl.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/FavoriteResourcesImpl.cs
@@ -100,7 +100,7 @@ namespace Smartsheet.Api.Internal
         /// <returns>A single Favorite object (note that a 404 status will be returned if the object is not currently favorited).</returns>
         /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
         /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
-        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
         /// <exception cref="ResourceNotFoundException"> if the resource cannot be found or the object is not a favorite</exception>
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/FavoriteResourcesImpl.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/FavoriteResourcesImpl.cs
@@ -92,6 +92,24 @@ namespace Smartsheet.Api.Internal
         }
 
         /// <summary>
+        /// <para>Gets a single Favorite item by type and objectId. If the object is not a favorite, a 404 status will be returned.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /favorites/{favoriteType}/{objectId}</para>
+        /// </summary>
+        /// <param name="type">(required): the object type</param>
+        /// <param name="objectId">(required): object ID representing a single favorited item.</param>
+        /// <returns>A single Favorite object (note that a 404 status will be returned if the object is not currently favorited).</returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found or the object is not a favorite</exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public virtual Favorite IsFavorite(ObjectType type, long objectId)
+        {
+            return this.GetResource<Favorite>("favorites/" + Enum.GetName(typeof(ObjectType), type).ToLower() + "/" + objectId, typeof(Favorite));
+        }
+
+        /// <summary>
         /// <para>Removes one or multiple objects from the user’s list of Favorite items.</para>
         /// <para>objectIds must not be null or empty.</para>
         /// <para>It mirrors to the following Smartsheet REST API methods: 

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/AbstractSheet.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/AbstractSheet.cs
@@ -91,7 +91,7 @@ namespace Smartsheet.Api.Models
         /// <summary>
         /// Identifies whether the sheet is marked as a favorite
         /// </summary>
-        [Obsolete("Please use the isFavorite method in FavoriteResources instead")]
+        [Obsolete("Please use the IsFavorite method in FavoriteResources instead")]
         private bool? favorite;
 
         /// <summary>
@@ -296,7 +296,7 @@ namespace Smartsheet.Api.Models
         /// Returned only if the user has marked this sheet as a favorite in their Home tab (value = “true”).
         /// </summary>
         /// <returns> true if marked as favorite, false otherwise </returns>
-        [Obsolete("Please use the isFavorite method in FavoriteResources instead")]
+        [Obsolete("Please use the IsFavorite method in FavoriteResources instead")]
         public bool? Favorite
         {
             get { return favorite; }

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/AbstractSheet.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/AbstractSheet.cs
@@ -91,6 +91,7 @@ namespace Smartsheet.Api.Models
         /// <summary>
         /// Identifies whether the sheet is marked as a favorite
         /// </summary>
+        [Obsolete("Please use the isFavorite method in FavoriteResources instead")]
         private bool? favorite;
 
         /// <summary>
@@ -295,6 +296,7 @@ namespace Smartsheet.Api.Models
         /// Returned only if the user has marked this sheet as a favorite in their Home tab (value = “true”).
         /// </summary>
         /// <returns> true if marked as favorite, false otherwise </returns>
+        [Obsolete("Please use the isFavorite method in FavoriteResources instead")]
         public bool? Favorite
         {
             get { return favorite; }

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Folder.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Folder.cs
@@ -29,7 +29,7 @@ namespace Smartsheet.Api.Models
         /// <summary>
         /// Represents whether a folder is marked as a favorite in the Home folder
         /// </summary>
-        [Obsolete("Please use the isFavorite method in FavoriteResources instead")]
+        [Obsolete("Please use the IsFavorite method in FavoriteResources instead")]
         private bool? favorite;
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace Smartsheet.Api.Models
         /// Gets and sets whether this folder is favorited.
         /// </summary>
         /// <returns> the sheets </returns>
-        [Obsolete("Please use the isFavorite method in FavoriteResources instead")]
+        [Obsolete("Please use the IsFavorite method in FavoriteResources instead")]
         public bool? Favorite
         {
             get { return favorite; }

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Folder.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Folder.cs
@@ -29,6 +29,7 @@ namespace Smartsheet.Api.Models
         /// <summary>
         /// Represents whether a folder is marked as a favorite in the Home folder
         /// </summary>
+        [Obsolete("Please use the isFavorite method in FavoriteResources instead")]
         private bool? favorite;
 
         /// <summary>
@@ -65,6 +66,7 @@ namespace Smartsheet.Api.Models
         /// Gets and sets whether this folder is favorited.
         /// </summary>
         /// <returns> the sheets </returns>
+        [Obsolete("Please use the isFavorite method in FavoriteResources instead")]
         public bool? Favorite
         {
             get { return favorite; }

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Sight.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Sight.cs
@@ -51,7 +51,7 @@ namespace Smartsheet.Api.Models
         /// <summary>
         /// Indicates whether the user has marked the Sight as a favorite
         /// </summary>
-        [Obsolete("Please use the isFavorite method in FavoriteResources instead")]
+        [Obsolete("Please use the IsFavorite method in FavoriteResources instead")]
         private bool? favorite;
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace Smartsheet.Api.Models
         /// Indicates whether the user has marked the Sight as a favorite.
         /// </summary>
         /// <returns> the favorite flag </returns>
-        [Obsolete("Please use the isFavorite method in FavoriteResources instead")]
+        [Obsolete("Please use the IsFavorite method in FavoriteResources instead")]
         public Boolean? Favorite
         {
             get { return favorite; }

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Sight.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Sight.cs
@@ -51,6 +51,7 @@ namespace Smartsheet.Api.Models
         /// <summary>
         /// Indicates whether the user has marked the Sight as a favorite
         /// </summary>
+        [Obsolete("Please use the isFavorite method in FavoriteResources instead")]
         private bool? favorite;
 
         /// <summary>
@@ -123,6 +124,7 @@ namespace Smartsheet.Api.Models
         /// Indicates whether the user has marked the Sight as a favorite.
         /// </summary>
         /// <returns> the favorite flag </returns>
+        [Obsolete("Please use the isFavorite method in FavoriteResources instead")]
         public Boolean? Favorite
         {
             get { return favorite; }


### PR DESCRIPTION
This PR marks the favorite field and its getters and setters obsolete in the `AbstractSheet`, `Folder`, and `Sight` models.

This PR also adds support for the isFavorite endpoint in the public API. [API reference](https://smartsheet.redoc.ly/tag/favorites#operation/is-favorite) This includes the necessary integration tests.