### PR TITLE
Bump to 5.1.0 for Levi's isFavorite changes. 

### DIFF
--- a/smartsheet-csharp-sdk/smartsheet-csharp-sdk-v2.csproj
+++ b/smartsheet-csharp-sdk/smartsheet-csharp-sdk-v2.csproj
@@ -18,7 +18,7 @@
     <Authors>Smartsheet</Authors>
     <Product>smartsheet-csharp-sdk</Product>
     <PackageTags>Smartsheet Collaboration Project Management Excel spreadsheet</PackageTags>
-    <Version>5.0.0</Version>
+    <Version>5.1.0</Version>
     <AssemblyName>smartsheet-csharp-sdk</AssemblyName>
     <RootNamespace>smartsheet-csharp-sdk</RootNamespace>
     <Configuration>Debug</Configuration>


### PR DESCRIPTION
Bump to 5.1.0, this is for the addition of isFavorite and deprecation of favorite fields.