### PR TITLE
Fix Cell.Value String Conversion with EnableDecimalObjectValue=false

### DIFF
--- a/mock-api-test-sdk-net80/JsonSerializerPrimitiveValueTest.cs
+++ b/mock-api-test-sdk-net80/JsonSerializerPrimitiveValueTest.cs
@@ -1,0 +1,197 @@
+using System.Text;
+using Smartsheet.Api.Internal.Json;
+using Smartsheet.Api.Models;
+
+namespace mock_api_test_sdk_net80
+{
+    /// <summary>
+    /// Tests for verifying that primitive numeric values in Cell.Value are handled correctly
+    /// based on the EnableDecimalObjectValue setting. This addresses the issue reported in
+    /// https://github.com/smartsheet/smartsheet-csharp-sdk/discussions/151#discussioncomment-15516369
+    /// </summary>
+    [TestClass]
+    public class JsonSerializerPrimitiveValueTest
+    {
+        [TestMethod]
+        public void DefaultBehavior_CellValueAsDouble_ToStringReturnsWithoutDecimal()
+        {
+            // Arrange - simulate the JSON response from Smartsheet API
+            var serializer = new JsonNetSerializer();
+            // Ensure we're in default mode (should be unnecessary but makes it explicit)
+            serializer.EnableDecimalObjectValue = false;
+
+            var json = @"{
+                ""id"": 123,
+                ""columnId"": 456,
+                ""value"": 65.0
+            }";
+
+            // Act
+            var cell = DeserializeCell(serializer, json);
+            var valueAsString = Convert.ToString(cell.Value);
+
+            // Assert
+            Assert.IsNotNull(cell);
+            Assert.IsNotNull(cell.Value);
+            // The key assertion: Convert.ToString should return "65" not "65.0"
+            Assert.AreEqual("65", valueAsString, "Cell value 65.0 should convert to string as '65' when EnableDecimalObjectValue is false");
+        }
+
+        [TestMethod]
+        public void DefaultBehavior_CellValueAsInteger_ToStringReturnsCorrectly()
+        {
+            // Arrange
+            var serializer = new JsonNetSerializer();
+            serializer.EnableDecimalObjectValue = false;
+
+            var json = @"{
+                ""id"": 123,
+                ""columnId"": 456,
+                ""value"": 65
+            }";
+
+            // Act
+            var cell = DeserializeCell(serializer, json);
+            var valueAsString = Convert.ToString(cell.Value);
+
+            // Assert
+            Assert.IsNotNull(cell);
+            Assert.IsNotNull(cell.Value);
+            Assert.AreEqual("65", valueAsString, "Cell value 65 should convert to string as '65'");
+        }
+
+        [TestMethod]
+        public void DecimalMode_CellValueAsDecimal_ToStringIncludesDecimal()
+        {
+            // Arrange
+            var serializer = new JsonNetSerializer();
+            serializer.EnableDecimalObjectValue = true;
+
+            var json = @"{
+                ""id"": 123,
+                ""columnId"": 456,
+                ""value"": 65.0
+            }";
+
+            // Act
+            var cell = DeserializeCell(serializer, json);
+            var valueAsString = Convert.ToString(cell.Value);
+
+            // Assert
+            Assert.IsNotNull(cell);
+            Assert.IsNotNull(cell.Value);
+            // In decimal mode, we expect "65.0"
+            Assert.AreEqual("65.0", valueAsString, "Cell value 65.0 should convert to string as '65.0' when EnableDecimalObjectValue is true");
+        }
+
+        [TestMethod]
+        public void DefaultBehavior_ComplexFilterScenario_StringComparisonWorks()
+        {
+            // Arrange - simulates the user's actual scenario from the discussion
+            var serializer = new JsonNetSerializer();
+            serializer.EnableDecimalObjectValue = false;
+
+            var json = @"{
+                ""id"": 123,
+                ""columnId"": 456,
+                ""value"": 65.0
+            }";
+
+            var cell = DeserializeCell(serializer, json);
+            string filterValue = "65";
+
+            // Act - This is similar to what the user's code does
+            var cellValueAsString = Convert.ToString(cell.Value);
+            bool matches = cellValueAsString.Equals(filterValue);
+
+            // Assert
+            Assert.IsTrue(matches, "String comparison should work: Convert.ToString(65.0) should equal '65' in default mode");
+        }
+
+        [TestMethod]
+        public void DefaultBehavior_FloatValueWithDecimals_PreservesDecimals()
+        {
+            // Arrange
+            var serializer = new JsonNetSerializer();
+            serializer.EnableDecimalObjectValue = false;
+
+            var json = @"{
+                ""id"": 123,
+                ""columnId"": 456,
+                ""value"": 65.5
+            }";
+
+            // Act
+            var cell = DeserializeCell(serializer, json);
+            var valueAsString = Convert.ToString(cell.Value);
+
+            // Assert
+            Assert.IsNotNull(cell);
+            Assert.IsNotNull(cell.Value);
+            Assert.AreEqual("65.5", valueAsString, "Cell value 65.5 should convert to string as '65.5'");
+        }
+
+        [TestMethod]
+        public void DefaultBehavior_NegativeValue_ToStringCorrect()
+        {
+            // Arrange
+            var serializer = new JsonNetSerializer();
+            serializer.EnableDecimalObjectValue = false;
+
+            var json = @"{
+                ""id"": 123,
+                ""columnId"": 456,
+                ""value"": -42.0
+            }";
+
+            // Act
+            var cell = DeserializeCell(serializer, json);
+            var valueAsString = Convert.ToString(cell.Value);
+
+            // Assert
+            Assert.IsNotNull(cell);
+            Assert.IsNotNull(cell.Value);
+            Assert.AreEqual("-42", valueAsString, "Cell value -42.0 should convert to string as '-42' when EnableDecimalObjectValue is false");
+        }
+
+        [TestMethod]
+        public void SwitchBetweenModes_BehaviorChangesCorrectly()
+        {
+            // Arrange
+            var serializer = new JsonNetSerializer();
+            var json = @"{
+                ""id"": 123,
+                ""columnId"": 456,
+                ""value"": 65.0
+            }";
+
+            // Act & Assert - Test default mode
+            serializer.EnableDecimalObjectValue = false;
+            var cell1 = DeserializeCell(serializer, json);
+            Assert.AreEqual("65", Convert.ToString(cell1.Value), "Should be '65' in default mode");
+
+            // Act & Assert - Switch to decimal mode
+            serializer.EnableDecimalObjectValue = true;
+            var cell2 = DeserializeCell(serializer, json);
+            Assert.AreEqual("65.0", Convert.ToString(cell2.Value), "Should be '65.0' in decimal mode");
+
+            // Act & Assert - Switch back to default mode
+            serializer.EnableDecimalObjectValue = false;
+            var cell3 = DeserializeCell(serializer, json);
+            Assert.AreEqual("65", Convert.ToString(cell3.Value), "Should be '65' again in default mode");
+        }
+
+        #region Helper Methods
+
+        private Cell DeserializeCell(JsonNetSerializer serializer, string json)
+        {
+            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(json)))
+            using (var reader = new StreamReader(stream))
+            {
+                return serializer.deserialize<Cell>(reader);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Json/JsonNetSerializer.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Json/JsonNetSerializer.cs
@@ -66,8 +66,9 @@ namespace Smartsheet.Api.Internal.Json
             // Disable converting strings that "look like" dates to C# DateTime objects
             serializer.DateParseHandling = DateParseHandling.None;
 
-            // Use Decimal for all floating point numbers to avoid precision loss
-            serializer.FloatParseHandling = FloatParseHandling.Decimal;
+            // Default to Double for backwards compatibility
+            // Can be changed to Decimal via EnableDecimalObjectValue property
+            serializer.FloatParseHandling = FloatParseHandling.Double;
 
             // Only include non-null properties in when serializing
             serializer.NullValueHandling = NullValueHandling.Ignore;
@@ -132,6 +133,10 @@ namespace Smartsheet.Api.Internal.Json
         {
             set
             {
+                // Set FloatParseHandling to control how primitive numeric values are parsed
+                // This fixes the issue where Cell.Value contains decimal primitives even when DecimalObjectValue is disabled
+                serializer.FloatParseHandling = value ? FloatParseHandling.Decimal : FloatParseHandling.Double;
+
                 // Replace the existing CellTypeConverter with a new one with the desired setting
                 var oldCellTypeConverter = serializer.Converters.OfType<CellTypeConverter>().FirstOrDefault();
                 if (oldCellTypeConverter != null)


### PR DESCRIPTION
### Summary
Reverts the default `FloatParseHandling` setting to `Double` and ensures it dynamically changes based on the `EnableDecimalObjectValue` property. This fixes a regression introduced in v6.6.3 where `Cell.Value` primitives were incorrectly parsed as `decimal` even when `EnableDecimalObjectValue` was disabled or not explicitly set.

### Problem
After PR #134 changed the default `FloatParseHandling` to `Decimal`, users experienced unexpected behavior where numeric values like `65.0` would be converted to the string `"65.0"` instead of `"65"` when using `Convert.ToString()` on `Cell.Value`. This broke existing code that relied on string comparisons of numeric cell values.

**User Impact:** String filtering logic that previously worked (e.g., comparing `Convert.ToString(cell.Value)` to `"65"`) stopped working because `65.0` was now being parsed as a `decimal` primitive, which converts to string as `"65.0"` rather than `"65"`.

**Root Cause:** The `FloatParseHandling.Decimal` setting was applied globally to the serializer, affecting all primitive numeric values, not just `ObjectValue` types. This happened even when `EnableDecimalObjectValue` was `false`.

### Solution
1. **Reverted default `FloatParseHandling` to `Double`** ([JsonNetSerializer.cs:71](smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Json/JsonNetSerializer.cs#L71)) - maintains backwards compatibility by default
2. **Added dynamic `FloatParseHandling` switching** ([JsonNetSerializer.cs:136-138](smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Json/JsonNetSerializer.cs#L136-L138)) - when `EnableDecimalObjectValue` is set, the serializer's `FloatParseHandling` is now updated accordingly:
   - `true` → `FloatParseHandling.Decimal` (preserves decimal precision)
   - `false` → `FloatParseHandling.Double` (default behavior, better string conversion)

### Testing
Added comprehensive unit tests in `JsonSerializerPrimitiveValueTest.cs` to verify:
- ✅ Default behavior: `65.0` → `"65"` when `EnableDecimalObjectValue = false`
- ✅ Decimal mode: `65.0` → `"65.0"` when `EnableDecimalObjectValue = true`
- ✅ String comparison scenarios work correctly
- ✅ Values with actual decimals are preserved (`65.5` → `"65.5"`)
- ✅ Mode switching works correctly

### Related Issues
Fixes the regression reported in [Discussion #151](https://github.com/smartsheet/smartsheet-csharp-sdk/discussions/151#discussioncomment-15516369)

### Breaking Changes
None. This restores the original default behavior from before v6.6.3.
