### PR TITLE
refactor: change variable name used in testing

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -148,9 +148,9 @@ To add new mock API tests:
     public void TestListUserPlansAllResponseBodyProperties()
     {
         Guid requestId = Guid.NewGuid();
-        SmartsheetClient ss = HelperFunctions.SetupClient("/users/list-user-plans/all-response-body-properties", requestId.ToString());
+        SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/list-user-plans/all-response-body-properties", requestId.ToString());
 
-        TokenPaginatedResult<UserPlan> response = ss.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, TEST_LAST_KEY, TEST_MAX_ITEMS);
+        TokenPaginatedResult<UserPlan> response = smartsheet.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, TEST_LAST_KEY, TEST_MAX_ITEMS);
 
         Assert.IsNotNull(response);
     }

--- a/mock-api-test-sdk-net80/AssetSharingResourcesContractTest.cs
+++ b/mock-api-test-sdk-net80/AssetSharingResourcesContractTest.cs
@@ -100,7 +100,7 @@ namespace mock_api_test_sdk_net80
 
             AssetType assetType = AssetType.SHEET;
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.AssetSharingResources.ListAssetShares(assetType, TEST_ASSET_ID, null, null));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => smartsheet.AssetSharingResources.ListAssetShares(assetType, TEST_ASSET_ID, null, null));
             Assert.AreEqual("Internal Server Error", exception.Message);
         }
 
@@ -112,7 +112,7 @@ namespace mock_api_test_sdk_net80
 
             AssetType assetType = AssetType.SHEET;
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.AssetSharingResources.ListAssetShares(assetType, TEST_ASSET_ID, null, null));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => smartsheet.AssetSharingResources.ListAssetShares(assetType, TEST_ASSET_ID, null, null));
             Assert.AreEqual("Malformed Request", exception.Message);
         }
 
@@ -188,7 +188,7 @@ namespace mock_api_test_sdk_net80
             AssetType assetType = AssetType.SHEET;
             string shareId = TEST_SHARE_ID;
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.AssetSharingResources.GetAssetShare(assetType, TEST_ASSET_ID, shareId));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => smartsheet.AssetSharingResources.GetAssetShare(assetType, TEST_ASSET_ID, shareId));
             Assert.AreEqual("Internal Server Error", exception.Message);
         }
 
@@ -201,7 +201,7 @@ namespace mock_api_test_sdk_net80
             AssetType assetType = AssetType.SHEET;
             string shareId = TEST_SHARE_ID;
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.AssetSharingResources.GetAssetShare(assetType, TEST_ASSET_ID, shareId));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => smartsheet.AssetSharingResources.GetAssetShare(assetType, TEST_ASSET_ID, shareId));
             Assert.AreEqual("Malformed Request", exception.Message);
         }
 
@@ -344,7 +344,7 @@ namespace mock_api_test_sdk_net80
                 .SetEmail(TEST_EMAIL)
                 .Build();
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.AssetSharingResources.ShareAsset(assetType, TEST_ASSET_ID, new List<AssetShare> { newShare }, false));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => smartsheet.AssetSharingResources.ShareAsset(assetType, TEST_ASSET_ID, new List<AssetShare> { newShare }, false));
             Assert.AreEqual("Internal Server Error", exception.Message);
         }
 
@@ -360,7 +360,7 @@ namespace mock_api_test_sdk_net80
                 .SetEmail("invalid-email")
                 .Build();
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.AssetSharingResources.ShareAsset(assetType, TEST_ASSET_ID, new List<AssetShare> { newShare }, false));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => smartsheet.AssetSharingResources.ShareAsset(assetType, TEST_ASSET_ID, new List<AssetShare> { newShare }, false));
             Assert.AreEqual("Malformed Request", exception.Message);
         }
 
@@ -451,7 +451,7 @@ namespace mock_api_test_sdk_net80
                 AccessLevel = AccessLevel.ADMIN
             };
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.AssetSharingResources.UpdateAssetShare(assetType, TEST_ASSET_ID, shareId, updateRequest));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => smartsheet.AssetSharingResources.UpdateAssetShare(assetType, TEST_ASSET_ID, shareId, updateRequest));
             Assert.AreEqual("Internal Server Error", exception.Message);
         }
 
@@ -469,7 +469,7 @@ namespace mock_api_test_sdk_net80
                 AccessLevel = AccessLevel.ADMIN
             };
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.AssetSharingResources.UpdateAssetShare(assetType, TEST_ASSET_ID, shareId, updateRequest));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => smartsheet.AssetSharingResources.UpdateAssetShare(assetType, TEST_ASSET_ID, shareId, updateRequest));
             Assert.AreEqual("Malformed Request", exception.Message);
         }
 
@@ -519,7 +519,7 @@ namespace mock_api_test_sdk_net80
             AssetType assetType = AssetType.SHEET;
             string shareId = TEST_SHARE_ID;
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.AssetSharingResources.DeleteAssetShare(assetType, TEST_ASSET_ID, shareId));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => smartsheet.AssetSharingResources.DeleteAssetShare(assetType, TEST_ASSET_ID, shareId));
             Assert.AreEqual("Internal Server Error", exception.Message);
         }
 
@@ -532,7 +532,7 @@ namespace mock_api_test_sdk_net80
             AssetType assetType = AssetType.SHEET;
             string shareId = TEST_SHARE_ID;
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.AssetSharingResources.DeleteAssetShare(assetType, TEST_ASSET_ID, shareId));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => smartsheet.AssetSharingResources.DeleteAssetShare(assetType, TEST_ASSET_ID, shareId));
             Assert.AreEqual("Malformed Request", exception.Message);
         }
     }

--- a/mock-api-test-sdk-net80/AssetSharingResourcesContractTest.cs
+++ b/mock-api-test-sdk-net80/AssetSharingResourcesContractTest.cs
@@ -23,14 +23,14 @@ namespace mock_api_test_sdk_net80
         public async Task TestListAssetSharesGeneratedUrlIsCorrect()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/sharing/list-asset-shares/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/sharing/list-asset-shares/all-response-body-properties", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
             ShareScope sharingInclude = ShareScope.Item;
 
             TokenPaginationParameters pagination = new TokenPaginationParameters(TEST_LAST_KEY, TEST_MAX_ITEMS);
 
-            ss.AssetSharingResources.ListAssetShares(assetType, TEST_ASSET_ID, pagination, sharingInclude);
+            smartsheet.AssetSharingResources.ListAssetShares(assetType, TEST_ASSET_ID, pagination, sharingInclude);
             WiremockHelper wiremockHelper = new WiremockHelper();
             LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
             Assert.IsNotNull(foundRequest);
@@ -52,11 +52,11 @@ namespace mock_api_test_sdk_net80
         public void TestListAssetSharesAllResponseBodyProperties()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/sharing/list-asset-shares/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/sharing/list-asset-shares/all-response-body-properties", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
 
-            ListAssetSharesResponse response = ss.AssetSharingResources.ListAssetShares(assetType, TEST_ASSET_ID, null, null);
+            ListAssetSharesResponse response = smartsheet.AssetSharingResources.ListAssetShares(assetType, TEST_ASSET_ID, null, null);
 
             Assert.IsNotNull(response);
             Assert.IsNotNull(response.LastKey);
@@ -78,11 +78,11 @@ namespace mock_api_test_sdk_net80
         public void TestListAssetSharesRequiredResponseBodyProperties()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/sharing/list-asset-shares/required-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/sharing/list-asset-shares/required-response-body-properties", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
 
-            ListAssetSharesResponse response = ss.AssetSharingResources.ListAssetShares(assetType, TEST_ASSET_ID, null, null);
+            ListAssetSharesResponse response = smartsheet.AssetSharingResources.ListAssetShares(assetType, TEST_ASSET_ID, null, null);
 
             Assert.IsNotNull(response);
             Assert.IsNotNull(response.Items);
@@ -96,11 +96,11 @@ namespace mock_api_test_sdk_net80
         public void TestListAssetSharesError500Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/500-response",requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response",requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => ss.AssetSharingResources.ListAssetShares(assetType, TEST_ASSET_ID, null, null));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.AssetSharingResources.ListAssetShares(assetType, TEST_ASSET_ID, null, null));
             Assert.AreEqual("Internal Server Error", exception.Message);
         }
 
@@ -108,11 +108,11 @@ namespace mock_api_test_sdk_net80
         public void TestListAssetSharesError400Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => ss.AssetSharingResources.ListAssetShares(assetType, TEST_ASSET_ID, null, null));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.AssetSharingResources.ListAssetShares(assetType, TEST_ASSET_ID, null, null));
             Assert.AreEqual("Malformed Request", exception.Message);
         }
 
@@ -120,12 +120,12 @@ namespace mock_api_test_sdk_net80
         public async Task TestGetAssetShareGeneratedUrlIsCorrect()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/sharing/get-asset-share/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/sharing/get-asset-share/all-response-body-properties", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
             string shareId = TEST_SHARE_ID;
 
-            ss.AssetSharingResources.GetAssetShare(assetType, TEST_ASSET_ID, shareId);
+            smartsheet.AssetSharingResources.GetAssetShare(assetType, TEST_ASSET_ID, shareId);
             WiremockHelper wiremockHelper = new WiremockHelper();
             LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
             Assert.IsNotNull(foundRequest);
@@ -144,12 +144,12 @@ namespace mock_api_test_sdk_net80
         public void TestGetAssetShareAllResponseBodyProperties()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/sharing/get-asset-share/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/sharing/get-asset-share/all-response-body-properties", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
             string shareId = TEST_SHARE_ID;
 
-            AssetShare response = ss.AssetSharingResources.GetAssetShare(assetType, TEST_ASSET_ID, shareId);
+            AssetShare response = smartsheet.AssetSharingResources.GetAssetShare(assetType, TEST_ASSET_ID, shareId);
 
             Assert.IsNotNull(response);
             Assert.AreEqual(TEST_ASSET_ID, response.Id);
@@ -166,12 +166,12 @@ namespace mock_api_test_sdk_net80
         public void TestGetAssetShareRequiredResponseBodyProperties()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/sharing/get-asset-share/required-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/sharing/get-asset-share/required-response-body-properties", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
             string shareId = TEST_SHARE_ID;
 
-            AssetShare response = ss.AssetSharingResources.GetAssetShare(assetType, TEST_ASSET_ID, shareId);
+            AssetShare response = smartsheet.AssetSharingResources.GetAssetShare(assetType, TEST_ASSET_ID, shareId);
 
             Assert.IsNotNull(response);
             Assert.AreEqual(TEST_ASSET_ID, response.Id);
@@ -183,12 +183,12 @@ namespace mock_api_test_sdk_net80
         public void TestGetAssetShareError500Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
             string shareId = TEST_SHARE_ID;
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => ss.AssetSharingResources.GetAssetShare(assetType, TEST_ASSET_ID, shareId));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.AssetSharingResources.GetAssetShare(assetType, TEST_ASSET_ID, shareId));
             Assert.AreEqual("Internal Server Error", exception.Message);
         }
 
@@ -196,12 +196,12 @@ namespace mock_api_test_sdk_net80
         public void TestGetAssetShareError400Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
             string shareId = TEST_SHARE_ID;
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => ss.AssetSharingResources.GetAssetShare(assetType, TEST_ASSET_ID, shareId));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.AssetSharingResources.GetAssetShare(assetType, TEST_ASSET_ID, shareId));
             Assert.AreEqual("Malformed Request", exception.Message);
         }
 
@@ -209,7 +209,7 @@ namespace mock_api_test_sdk_net80
         public async Task TestShareAssetGeneratedUrlIsCorrect()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/sharing/share-asset/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/sharing/share-asset/all-response-body-properties", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
             bool sendEmail = false;
@@ -218,7 +218,7 @@ namespace mock_api_test_sdk_net80
                 .SetEmail(TEST_EMAIL)
                 .Build();
 
-            ss.AssetSharingResources.ShareAsset(assetType, TEST_ASSET_ID, new List<AssetShare> { newShare }, sendEmail);
+            smartsheet.AssetSharingResources.ShareAsset(assetType, TEST_ASSET_ID, new List<AssetShare> { newShare }, sendEmail);
             WiremockHelper wiremockHelper = new WiremockHelper();
             LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
             Assert.IsNotNull(foundRequest);
@@ -253,7 +253,7 @@ namespace mock_api_test_sdk_net80
         public async Task TestShareAssetAllResponseBodyProperties()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/sharing/share-asset/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/sharing/share-asset/all-response-body-properties", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
 
@@ -261,7 +261,7 @@ namespace mock_api_test_sdk_net80
                 .SetEmail(TEST_EMAIL)
                 .Build();
 
-            BulkItemResult<AssetShare> response = ss.AssetSharingResources.ShareAsset(assetType, TEST_ASSET_ID, new List<AssetShare> { newShare }, false);
+            BulkItemResult<AssetShare> response = smartsheet.AssetSharingResources.ShareAsset(assetType, TEST_ASSET_ID, new List<AssetShare> { newShare }, false);
 
             WiremockHelper wiremockHelper = new WiremockHelper();
             LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
@@ -300,7 +300,7 @@ namespace mock_api_test_sdk_net80
         public async Task TestShareAssetRequiredResponseBodyProperties()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/sharing/share-asset/required-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/sharing/share-asset/required-response-body-properties", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
 
@@ -308,7 +308,7 @@ namespace mock_api_test_sdk_net80
                 .SetEmail(TEST_EMAIL)
                 .Build();
 
-            BulkItemResult<AssetShare> response = ss.AssetSharingResources.ShareAsset(assetType, TEST_ASSET_ID, new List<AssetShare> { newShare }, false);
+            BulkItemResult<AssetShare> response = smartsheet.AssetSharingResources.ShareAsset(assetType, TEST_ASSET_ID, new List<AssetShare> { newShare }, false);
 
             WiremockHelper wiremockHelper = new WiremockHelper();
             LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
@@ -336,7 +336,7 @@ namespace mock_api_test_sdk_net80
         public void TestShareAssetError500Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
 
@@ -344,7 +344,7 @@ namespace mock_api_test_sdk_net80
                 .SetEmail(TEST_EMAIL)
                 .Build();
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => ss.AssetSharingResources.ShareAsset(assetType, TEST_ASSET_ID, new List<AssetShare> { newShare }, false));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.AssetSharingResources.ShareAsset(assetType, TEST_ASSET_ID, new List<AssetShare> { newShare }, false));
             Assert.AreEqual("Internal Server Error", exception.Message);
         }
 
@@ -352,7 +352,7 @@ namespace mock_api_test_sdk_net80
         public void TestShareAssetError400Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
 
@@ -360,7 +360,7 @@ namespace mock_api_test_sdk_net80
                 .SetEmail("invalid-email")
                 .Build();
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => ss.AssetSharingResources.ShareAsset(assetType, TEST_ASSET_ID, new List<AssetShare> { newShare }, false));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.AssetSharingResources.ShareAsset(assetType, TEST_ASSET_ID, new List<AssetShare> { newShare }, false));
             Assert.AreEqual("Malformed Request", exception.Message);
         }
 
@@ -368,7 +368,7 @@ namespace mock_api_test_sdk_net80
         public async Task TestUpdateAssetShareGeneratedUrlIsCorrect()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/sharing/update-asset-share/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/sharing/update-asset-share/all-response-body-properties", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
             string shareId = TEST_SHARE_ID;
@@ -378,7 +378,7 @@ namespace mock_api_test_sdk_net80
                 AccessLevel = AccessLevel.ADMIN
             };
 
-            ss.AssetSharingResources.UpdateAssetShare(assetType, TEST_ASSET_ID, shareId, updateRequest);
+            smartsheet.AssetSharingResources.UpdateAssetShare(assetType, TEST_ASSET_ID, shareId, updateRequest);
             WiremockHelper wiremockHelper = new WiremockHelper();
             LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
             var uri = new Uri(foundRequest.AbsoluteUrl);
@@ -395,7 +395,7 @@ namespace mock_api_test_sdk_net80
         public void TestUpdateAssetShareAllResponseBodyProperties()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/sharing/update-asset-share/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/sharing/update-asset-share/all-response-body-properties", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
             string shareId = TEST_SHARE_ID;
@@ -405,7 +405,7 @@ namespace mock_api_test_sdk_net80
                 AccessLevel = AccessLevel.ADMIN
             };
 
-            AssetShare response = ss.AssetSharingResources.UpdateAssetShare(assetType, TEST_ASSET_ID, shareId, updateRequest);
+            AssetShare response = smartsheet.AssetSharingResources.UpdateAssetShare(assetType, TEST_ASSET_ID, shareId, updateRequest);
 
             Assert.IsNotNull(response);
             Assert.AreEqual(TEST_ASSET_ID, response.Id);
@@ -419,7 +419,7 @@ namespace mock_api_test_sdk_net80
         public void TestUpdateAssetShareRequiredResponseBodyProperties()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/sharing/update-asset-share/required-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/sharing/update-asset-share/required-response-body-properties", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
             string shareId = TEST_SHARE_ID;
@@ -429,7 +429,7 @@ namespace mock_api_test_sdk_net80
                 AccessLevel = AccessLevel.ADMIN
             };
 
-            AssetShare response = ss.AssetSharingResources.UpdateAssetShare(assetType, TEST_ASSET_ID, shareId, updateRequest);
+            AssetShare response = smartsheet.AssetSharingResources.UpdateAssetShare(assetType, TEST_ASSET_ID, shareId, updateRequest);
 
             Assert.IsNotNull(response);
             Assert.AreEqual(TEST_ASSET_ID, response.Id);
@@ -441,7 +441,7 @@ namespace mock_api_test_sdk_net80
         public void TestUpdateAssetShareError500Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
             string shareId = TEST_SHARE_ID;
@@ -451,7 +451,7 @@ namespace mock_api_test_sdk_net80
                 AccessLevel = AccessLevel.ADMIN
             };
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => ss.AssetSharingResources.UpdateAssetShare(assetType, TEST_ASSET_ID, shareId, updateRequest));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.AssetSharingResources.UpdateAssetShare(assetType, TEST_ASSET_ID, shareId, updateRequest));
             Assert.AreEqual("Internal Server Error", exception.Message);
         }
 
@@ -459,7 +459,7 @@ namespace mock_api_test_sdk_net80
         public void TestUpdateAssetShareError400Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
             string shareId = TEST_SHARE_ID;
@@ -469,7 +469,7 @@ namespace mock_api_test_sdk_net80
                 AccessLevel = AccessLevel.ADMIN
             };
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => ss.AssetSharingResources.UpdateAssetShare(assetType, TEST_ASSET_ID, shareId, updateRequest));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.AssetSharingResources.UpdateAssetShare(assetType, TEST_ASSET_ID, shareId, updateRequest));
             Assert.AreEqual("Malformed Request", exception.Message);
         }
 
@@ -477,12 +477,12 @@ namespace mock_api_test_sdk_net80
         public async Task TestDeleteAssetShareGeneratedUrlIsCorrect()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/sharing/delete-asset-share/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/sharing/delete-asset-share/all-response-body-properties", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
             string shareId = TEST_SHARE_ID;
 
-            ss.AssetSharingResources.DeleteAssetShare(assetType, TEST_ASSET_ID, shareId);
+            smartsheet.AssetSharingResources.DeleteAssetShare(assetType, TEST_ASSET_ID, shareId);
             WiremockHelper wiremockHelper = new WiremockHelper();
             LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
             Assert.IsNotNull(foundRequest);
@@ -501,25 +501,25 @@ namespace mock_api_test_sdk_net80
         public void TestDeleteAssetShareSuccess()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/sharing/delete-asset-share/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/sharing/delete-asset-share/all-response-body-properties", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
             string shareId = TEST_SHARE_ID;
 
             // Should not throw any exception
-            ss.AssetSharingResources.DeleteAssetShare(assetType, TEST_ASSET_ID, shareId);
+            smartsheet.AssetSharingResources.DeleteAssetShare(assetType, TEST_ASSET_ID, shareId);
         }
 
         [TestMethod]
         public void TestDeleteAssetShareError500Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
             string shareId = TEST_SHARE_ID;
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => ss.AssetSharingResources.DeleteAssetShare(assetType, TEST_ASSET_ID, shareId));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.AssetSharingResources.DeleteAssetShare(assetType, TEST_ASSET_ID, shareId));
             Assert.AreEqual("Internal Server Error", exception.Message);
         }
 
@@ -527,12 +527,12 @@ namespace mock_api_test_sdk_net80
         public void TestDeleteAssetShareError400Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
 
             AssetType assetType = AssetType.SHEET;
             string shareId = TEST_SHARE_ID;
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => ss.AssetSharingResources.DeleteAssetShare(assetType, TEST_ASSET_ID, shareId));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.AssetSharingResources.DeleteAssetShare(assetType, TEST_ASSET_ID, shareId));
             Assert.AreEqual("Malformed Request", exception.Message);
         }
     }

--- a/mock-api-test-sdk-net80/AutomationRulesTest.cs
+++ b/mock-api-test-sdk-net80/AutomationRulesTest.cs
@@ -10,8 +10,8 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void ListAutomationRules()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("List Automation Rules");
-            PaginatedResult<AutomationRule> automationRules = ss.SheetResources.AutomationRuleResources.ListAutomationRules(324);
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("List Automation Rules");
+            PaginatedResult<AutomationRule> automationRules = smartsheet.SheetResources.AutomationRuleResources.ListAutomationRules(324);
 
             Assert.IsNotNull(automationRules.TotalCount);
             Assert.AreEqual(2, (long)automationRules.TotalCount);
@@ -20,8 +20,8 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void GetAutomationRule()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Get Automation Rule");
-            AutomationRule automationRule = ss.SheetResources.AutomationRuleResources.GetAutomationRule(324, 284);
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Get Automation Rule");
+            AutomationRule automationRule = smartsheet.SheetResources.AutomationRuleResources.GetAutomationRule(324, 284);
             Assert.IsNotNull(automationRule.Id);
             Assert.AreEqual(284, (long)automationRule.Id);
         }
@@ -29,7 +29,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void UpdateAutomationRule()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Update Automation Rule");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Automation Rule");
             AutomationAction autoRuleAction = new AutomationAction();
             Recipient recipient = new Recipient();
             recipient.Email = "jane@example.com";
@@ -39,14 +39,14 @@ namespace mock_api_test_sdk_net80
             AutomationRule autoRule = new AutomationRule();
             autoRule.Id = 284;
             autoRule.Action = autoRuleAction;
-            AutomationRule automationRule = ss.SheetResources.AutomationRuleResources.UpdateAutomationRule(324, autoRule);
+            AutomationRule automationRule = smartsheet.SheetResources.AutomationRuleResources.UpdateAutomationRule(324, autoRule);
         }
 
         [TestMethod]
         public void DeleteAutomationRule()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Delete Automation Rule");
-            ss.SheetResources.AutomationRuleResources.DeleteAutomationRule(324, 284);
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Delete Automation Rule");
+            smartsheet.SheetResources.AutomationRuleResources.DeleteAutomationRule(324, 284);
         }
     }
 }

--- a/mock-api-test-sdk-net80/ColumnTests.cs
+++ b/mock-api-test-sdk-net80/ColumnTests.cs
@@ -10,7 +10,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void UpdateColumn_ChangeType_Picklist()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Update Column - Change Type - Picklist");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Column - Change Type - Picklist");
 
             Column column = new Column
             {
@@ -27,7 +27,7 @@ namespace mock_api_test_sdk_net80
                 Width = 200
             };
 
-            Column updatedColumn = ss.SheetResources.ColumnResources.UpdateColumn(123, column);
+            Column updatedColumn = smartsheet.SheetResources.ColumnResources.UpdateColumn(123, column);
 
             Assert.AreEqual(ColumnType.PICKLIST, updatedColumn.Type);
             Assert.AreEqual(3, updatedColumn.Options.Count);
@@ -36,7 +36,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void UpdateColumn_ChangeType_ContactList()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Update Column - Change Type - Contact List");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Column - Change Type - Contact List");
 
             Column column = new Column
             {
@@ -60,7 +60,7 @@ namespace mock_api_test_sdk_net80
                 Width = 200
             };
 
-            Column updatedColumn = ss.SheetResources.ColumnResources.UpdateColumn(123, column);
+            Column updatedColumn = smartsheet.SheetResources.ColumnResources.UpdateColumn(123, column);
 
             Assert.AreEqual(ColumnType.CONTACT_LIST, updatedColumn.Type);
             Assert.AreEqual(2, updatedColumn.ContactOptions.Count);

--- a/mock-api-test-sdk-net80/FolderTests.cs
+++ b/mock-api-test-sdk-net80/FolderTests.cs
@@ -11,10 +11,10 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void GetFolderChildren_NoParams()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Get Folder Children - No Params");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Get Folder Children - No Params");
 
             // No params - use minimal required parameters
-            TokenPaginatedResult<object> children = ss.FolderResources.GetFolderChildren(456);
+            TokenPaginatedResult<object> children = smartsheet.FolderResources.GetFolderChildren(456);
 
             Assert.IsNotNull(children);
             Assert.IsNotNull(children.Data);
@@ -50,10 +50,10 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void GetFolderChildren_IncludeSourceAndOwnerInfo()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Get Folder Children - Include Source and OwnerInfo");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Get Folder Children - Include Source and OwnerInfo");
 
             // Include source and owner info as specified in scenario title
-            TokenPaginatedResult<object> children = ss.FolderResources.GetFolderChildren(
+            TokenPaginatedResult<object> children = smartsheet.FolderResources.GetFolderChildren(
                 456,
                 null,
                 new List<ChildrenInclusion> { ChildrenInclusion.SOURCE, ChildrenInclusion.OWNER_INFO }
@@ -109,10 +109,10 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void GetFolderChildren_FilterSightsAndReports()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Get Folder Children - Filter Sights and Reports");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Get Folder Children - Filter Sights and Reports");
 
             // Filter to only sights and reports as specified in scenario title
-            TokenPaginatedResult<object> children = ss.FolderResources.GetFolderChildren(
+            TokenPaginatedResult<object> children = smartsheet.FolderResources.GetFolderChildren(
                 456,
                 new List<ChildrenResourceType> { ChildrenResourceType.REPORTS, ChildrenResourceType.SIGHTS }
             );
@@ -149,10 +149,10 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void GetFolderMetadata_NoParams()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Get Folder Metadata - No Params");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Get Folder Metadata - No Params");
 
             // No params - use minimal required parameters
-            Folder folder = ss.FolderResources.GetFolderMetadata(456);
+            Folder folder = smartsheet.FolderResources.GetFolderMetadata(456);
 
             Assert.IsNotNull(folder);
             Assert.AreEqual(456, folder.Id);
@@ -165,10 +165,10 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void GetFolderMetadata_IncludeSource()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Get Folder Metadata - Include Source");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Get Folder Metadata - Include Source");
 
             // Include source as specified in scenario title
-            Folder folder = ss.FolderResources.GetFolderMetadata(
+            Folder folder = smartsheet.FolderResources.GetFolderMetadata(
                 456,
                 new List<FolderInclusion> { FolderInclusion.SOURCE }
             );

--- a/mock-api-test-sdk-net80/HelperFunctions.cs
+++ b/mock-api-test-sdk-net80/HelperFunctions.cs
@@ -8,25 +8,25 @@ namespace mock_api_test_sdk_net80
         public static SmartsheetClient SetupClient(string apiScenario)
         {
             TestHttpClient testHttpClient = new TestHttpClient(apiScenario);
-            SmartsheetClient ss = new SmartsheetBuilder()
+            SmartsheetClient smartsheet = new SmartsheetBuilder()
             .SetBaseURI("http://localhost:8082/")
             .SetAccessToken("aaaaaaaaaaaaaaaaaaaaaaaaaa")
             .SetHttpClient(testHttpClient)
             .Build();
 
-            return ss;
+            return smartsheet;
         }
 
         public static SmartsheetClient SetupClient(string testName, string requestId)
         {
             TestHttpClientWithCustomHeader testHttpClient = new TestHttpClientWithCustomHeader(testName, requestId);
-            SmartsheetClient ss = new SmartsheetBuilder()
+            SmartsheetClient smartsheet = new SmartsheetBuilder()
             .SetBaseURI("http://localhost:8082/2.0/")
             .SetAccessToken("aaaaaaaaaaaaaaaaaaaaaaaaaa")
             .SetHttpClient(testHttpClient)
             .Build();
 
-            return ss;
+            return smartsheet;
         }
 
         ///<summary>

--- a/mock-api-test-sdk-net80/RowTests.cs
+++ b/mock-api-test-sdk-net80/RowTests.cs
@@ -10,7 +10,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void AddRows_AssignValues_String()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Add Rows - Assign Values - String");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Assign Values - String");
 
             Row rowA = new Row
             {
@@ -43,7 +43,7 @@ namespace mock_api_test_sdk_net80
             };
 
             // Update rows in sheet
-            IList<Row> addedRows = ss.SheetResources.RowResources.AddRows(1, new Row[] { rowA, rowB });
+            IList<Row> addedRows = smartsheet.SheetResources.RowResources.AddRows(1, new Row[] { rowA, rowB });
 
             Row? row = addedRows.FirstOrDefault(r => r.Id == 10);
             Cell? cell = row?.Cells.FirstOrDefault(c => c.Value.Equals("Apple"));
@@ -55,7 +55,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void AddRows_AssignValues_Int()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Add Rows - Assign Values - Int");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Assign Values - Int");
 
             Row rowA = new Row
             {
@@ -88,7 +88,7 @@ namespace mock_api_test_sdk_net80
             };
 
             // Update rows in sheet
-            IList<Row> addedRows = ss.SheetResources.RowResources.AddRows(1, new Row[] { rowA, rowB });
+            IList<Row> addedRows = smartsheet.SheetResources.RowResources.AddRows(1, new Row[] { rowA, rowB });
 
             Row? row = addedRows.FirstOrDefault(r => r.Id == 10);
             Cell? cell = row?.Cells.FirstOrDefault(c => Convert.ToInt32(c.Value) == 100);
@@ -99,7 +99,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void AddRows_AssignValues_Bool()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Add Rows - Assign Values - Bool");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Assign Values - Bool");
 
             Row rowA = new Row
             {
@@ -132,7 +132,7 @@ namespace mock_api_test_sdk_net80
             };
 
             // Update rows in sheet
-            IList<Row> addedRows = ss.SheetResources.RowResources.AddRows(1, new Row[] { rowA, rowB });
+            IList<Row> addedRows = smartsheet.SheetResources.RowResources.AddRows(1, new Row[] { rowA, rowB });
 
             Row? row = addedRows.FirstOrDefault(r => r.Id == 10);
             Cell? cell = row?.Cells.FirstOrDefault(c => c.Value.Equals(true));
@@ -145,7 +145,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void AddRows_AssignFormulae()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Add Rows - Assign Formulae");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Assign Formulae");
 
             Row rowA = new Row
             {
@@ -162,7 +162,7 @@ namespace mock_api_test_sdk_net80
                 }
             };
 
-            IList<Row> addedRows = ss.SheetResources.RowResources.AddRows(1, new Row[] { rowA });
+            IList<Row> addedRows = smartsheet.SheetResources.RowResources.AddRows(1, new Row[] { rowA });
 
             Cell? cell = addedRows[0].Cells.FirstOrDefault(c => c.Formula.Equals("=SUM([Column2]3, [Column2]3, [Column2]4)"));
             Assert.IsNotNull(cell);
@@ -172,7 +172,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void AddRows_AssignValues_Hyperlink()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Add Rows - Assign Values - Hyperlink");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Assign Values - Hyperlink");
 
             Row rowA = new Row
             {
@@ -195,7 +195,7 @@ namespace mock_api_test_sdk_net80
                 }
             };
 
-            IList<Row> addedRows = ss.SheetResources.RowResources.AddRows(1, new Row[] { rowA });
+            IList<Row> addedRows = smartsheet.SheetResources.RowResources.AddRows(1, new Row[] { rowA });
 
             Cell? cell = addedRows[0].Cells.FirstOrDefault(c => c.Value.Equals("Google"));
             Assert.IsNotNull(cell);
@@ -208,7 +208,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void AddRows_AssignValues_HyperlinkSheetID()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Add Rows - Assign Values - Hyperlink SheetID");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Assign Values - Hyperlink SheetID");
 
             Row rowA = new Row
             {
@@ -231,7 +231,7 @@ namespace mock_api_test_sdk_net80
                 }
             };
 
-            IList<Row> addedRows = ss.SheetResources.RowResources.AddRows(1, new Row[] { rowA });
+            IList<Row> addedRows = smartsheet.SheetResources.RowResources.AddRows(1, new Row[] { rowA });
             var cellsValue = addedRows[0].Cells;
             Cell? cell = cellsValue.FirstOrDefault(c => c.Value.Equals("Sheet3"));
             Assert.IsNotNull(cell);
@@ -244,7 +244,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void AddRows_AssignValues_HyperlinkReportID()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Add Rows - Assign Values - Hyperlink ReportID");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Assign Values - Hyperlink ReportID");
 
             Row rowA = new Row
             {
@@ -267,7 +267,7 @@ namespace mock_api_test_sdk_net80
                 }
             };
 
-            IList<Row> addedRows = ss.SheetResources.RowResources.AddRows(1, new Row[] { rowA });
+            IList<Row> addedRows = smartsheet.SheetResources.RowResources.AddRows(1, new Row[] { rowA });
 
             Cell? cell = addedRows[0].Cells.FirstOrDefault(c => c.Value.Equals("Report8"));
             Assert.IsNotNull(cell);
@@ -280,7 +280,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void AddRows_Invalid_AssignValueAndFormulae()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Add Rows - Invalid - Assign Value and Formulae");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Invalid - Assign Value and Formulae");
 
             Row rowA = new Row
             {
@@ -300,14 +300,14 @@ namespace mock_api_test_sdk_net80
             };
 
             HelperFunctions.AssertRaisesException<SmartsheetException>(() =>
-                ss.SheetResources.RowResources.AddRows(1, new Row[] { rowA }),
+                smartsheet.SheetResources.RowResources.AddRows(1, new Row[] { rowA }),
                 "If cell.formula is specified, then value, objectValue, image, hyperlink, and linkInFromCell must not be specified.");
         }
 
         [TestMethod]
         public void AddRows_Invalid_AssignHyperlinkUrlandSheetId()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Add Rows - Invalid - Assign Hyperlink URL and SheetId");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Invalid - Assign Hyperlink URL and SheetId");
 
             Row rowA = new Row
             {
@@ -333,14 +333,14 @@ namespace mock_api_test_sdk_net80
 
 
             HelperFunctions.AssertRaisesException<SmartsheetException>(() =>
-                ss.SheetResources.RowResources.AddRows(1, new Row[] { rowA }),
+                smartsheet.SheetResources.RowResources.AddRows(1, new Row[] { rowA }),
                 "hyperlink.url must be null for sheet, report, or Sight hyperlinks.");
         }
 
         [TestMethod]
         public void AddRows_AssignObjectValue_PredecessorList()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Add Rows - Assign Object Value - Predecessor List (using floats)");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Assign Object Value - Predecessor List (using floats)");
 
             Row rowA = new Row
             {
@@ -368,7 +368,7 @@ namespace mock_api_test_sdk_net80
                 }
             };
 
-            IList<Row> addedRows = ss.SheetResources.RowResources.AddRows(1, new Row[] { rowA });
+            IList<Row> addedRows = smartsheet.SheetResources.RowResources.AddRows(1, new Row[] { rowA });
 
             Cell predecessorCell = addedRows[0].Cells.Single(c => c.ColumnId == 101);
             Assert.AreEqual("2FS +2.5d", predecessorCell.Value);
@@ -377,7 +377,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void AddRows_Location_Top()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Add Rows - Location - Top");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Location - Top");
 
             Row rowA = new Row
             {
@@ -396,7 +396,7 @@ namespace mock_api_test_sdk_net80
             };
 
             // Update rows in sheet
-            IList<Row> addedRows = ss.SheetResources.RowResources.AddRows(1, new Row[] { rowA });
+            IList<Row> addedRows = smartsheet.SheetResources.RowResources.AddRows(1, new Row[] { rowA });
 
             Row? row = addedRows.FirstOrDefault(r => r.Id == 10);
             Cell? cell = row?.Cells.FirstOrDefault(c => c.Value.Equals("Apple"));
@@ -409,7 +409,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void AddRows_Location_Bottom()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Add Rows - Location - Bottom");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Location - Bottom");
 
             Row rowA = new Row
             {
@@ -428,7 +428,7 @@ namespace mock_api_test_sdk_net80
             };
 
             // Update rows in sheet
-            IList<Row> addedRows = ss.SheetResources.RowResources.AddRows(1, new Row[] { rowA });
+            IList<Row> addedRows = smartsheet.SheetResources.RowResources.AddRows(1, new Row[] { rowA });
 
             Row? row = addedRows.FirstOrDefault(r => r.Id == 10);
             Cell? cell = row?.Cells.FirstOrDefault(c => c.Value.Equals("Apple"));
@@ -441,7 +441,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void UpdateRows_AssignValues_String()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Update Rows - Assign Values - String");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Assign Values - String");
 
             Row rowA = new Row
             {
@@ -476,7 +476,7 @@ namespace mock_api_test_sdk_net80
             };
 
             // Update rows in sheet
-            IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA, rowB });
+            IList<Row> updatedRows = smartsheet.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA, rowB });
 
             Row? row = updatedRows.Where(r => r.Id == 10).FirstOrDefault();
             Cell? cell = row?.Cells.Where(c => c.Value.Equals("Apple")).FirstOrDefault();
@@ -487,7 +487,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void UpdateRows_AssignValues_Int()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Update Rows - Assign Values - Int");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Assign Values - Int");
 
             Row rowA = new Row
             {
@@ -522,7 +522,7 @@ namespace mock_api_test_sdk_net80
             };
 
             // Update rows in sheet
-            IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, [rowA, rowB]);
+            IList<Row> updatedRows = smartsheet.SheetResources.RowResources.UpdateRows(1, [rowA, rowB]);
             Row? row = updatedRows.FirstOrDefault(r => r.Id == 10);
             Cell? cell = row?.Cells.FirstOrDefault(c => Convert.ToInt32(c.Value) == 100);
             Assert.IsNotNull(cell);
@@ -532,7 +532,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void UpdateRows_AssignValues_Bool()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Update Rows - Assign Values - Bool");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Assign Values - Bool");
 
             Row rowA = new Row
             {
@@ -567,7 +567,7 @@ namespace mock_api_test_sdk_net80
             };
 
             // Update rows in sheet
-            IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA, rowB });
+            IList<Row> updatedRows = smartsheet.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA, rowB });
 
             Row? row = updatedRows.FirstOrDefault(r => r.Id == 10);
             Cell? cell = row?.Cells.FirstOrDefault(c => c.Value.Equals(true));
@@ -578,7 +578,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void UpdateRows_AssignFormulae()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Update Rows - Assign Formulae");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Assign Formulae");
 
             Row rowA = new Row
             {
@@ -596,7 +596,7 @@ namespace mock_api_test_sdk_net80
                 }
             };
 
-            IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
+            IList<Row> updatedRows = smartsheet.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
 
             Cell? cell = updatedRows[0].Cells.Where(c => c.Formula.Equals("=SUM([Column2]3, [Column2]3, [Column2]4)")).FirstOrDefault();
             Assert.IsNotNull(cell);
@@ -606,7 +606,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void UpdateRows_AssignValues_Hyperlink()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Update Rows - Assign Values - Hyperlink");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Assign Values - Hyperlink");
 
             Row rowA = new Row
             {
@@ -630,7 +630,7 @@ namespace mock_api_test_sdk_net80
                 }
             };
 
-            IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
+            IList<Row> updatedRows = smartsheet.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
 
             Cell? cell = updatedRows[0].Cells.Where(c => c.Value.Equals("Google")).FirstOrDefault();
             Assert.IsNotNull(cell);
@@ -643,7 +643,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void UpdateRows_AssignValues_HyperlinkSheetID()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Update Rows - Assign Values - Hyperlink SheetID");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Assign Values - Hyperlink SheetID");
 
             Row rowA = new Row
             {
@@ -667,7 +667,7 @@ namespace mock_api_test_sdk_net80
                 }
             };
 
-            IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
+            IList<Row> updatedRows = smartsheet.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
             var cells = updatedRows[0].Cells;
             Assert.IsNotNull(cells);
             Cell? cell = cells.FirstOrDefault(c => c.Value.Equals("Sheet3"));
@@ -681,7 +681,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void UpdateRows_AssignValues_HyperlinkReportID()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Update Rows - Assign Values - Hyperlink ReportID");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Assign Values - Hyperlink ReportID");
 
             Row rowA = new Row
             {
@@ -705,7 +705,7 @@ namespace mock_api_test_sdk_net80
                 }
             };
 
-            IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
+            IList<Row> updatedRows = smartsheet.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
 
             Cell? cell = updatedRows[0].Cells.FirstOrDefault(c => c.Value.Equals("Report8"));
             Assert.IsNotNull(cell);
@@ -718,7 +718,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void UpdateRows_Invalid_AssignValueAndFormulae()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Update Rows - Invalid - Assign Value and Formulae");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Invalid - Assign Value and Formulae");
 
             Row rowA = new Row
             {
@@ -739,14 +739,14 @@ namespace mock_api_test_sdk_net80
             };
 
             HelperFunctions.AssertRaisesException<SmartsheetException>(() =>
-                ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA }),
+                smartsheet.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA }),
                 "If cell.formula is specified, then value, objectValue, image, hyperlink, and linkInFromCell must not be specified.");
         }
 
         [TestMethod]
         public void UpdateRows_Invalid_AssignHyperlinkUrlandSheetId()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Update Rows - Invalid - Assign Hyperlink URL and SheetId");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Invalid - Assign Hyperlink URL and SheetId");
 
             Row rowA = new Row
             {
@@ -772,14 +772,14 @@ namespace mock_api_test_sdk_net80
             };
 
             HelperFunctions.AssertRaisesException<SmartsheetException>(() =>
-                ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA }),
+                smartsheet.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA }),
                 "hyperlink.url must be null for sheet, report, or Sight hyperlinks.");
         }
 
         [TestMethod]
         public void UpdateRows_ClearValue_TextNumber()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Update Rows - Clear Value - Text Number");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Clear Value - Text Number");
 
             Row rowA = new Row
             {
@@ -794,7 +794,7 @@ namespace mock_api_test_sdk_net80
                 }
             };
 
-            IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
+            IList<Row> updatedRows = smartsheet.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
 
             Cell updatedCell = updatedRows[0].Cells.Single(c => c.ColumnId == 101);
             Assert.AreEqual(null, updatedCell.Value);
@@ -803,7 +803,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void UpdateRows_ClearValue_Checkbox()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Update Rows - Clear Value - Checkbox");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Clear Value - Checkbox");
 
             Row rowA = new Row
             {
@@ -818,7 +818,7 @@ namespace mock_api_test_sdk_net80
                 }
             };
 
-            IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
+            IList<Row> updatedRows = smartsheet.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
 
             Cell updatedCell = updatedRows[0].Cells.Single(c => c.ColumnId == 101);
             Assert.AreEqual(false, updatedCell.Value);
@@ -827,7 +827,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void UpdateRows_ClearValue_Hyperlink()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Update Rows - Clear Value - Hyperlink");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Clear Value - Hyperlink");
 
             Row rowA = new Row
             {
@@ -843,7 +843,7 @@ namespace mock_api_test_sdk_net80
                 }
             };
 
-            IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
+            IList<Row> updatedRows = smartsheet.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
 
             Cell updatedCell = updatedRows[0].Cells.Single(c => c.ColumnId == 101);
             Assert.AreEqual(null, updatedCell.Hyperlink);
@@ -853,7 +853,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void UpdateRows_ClearValue_CellLink()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Update Rows - Clear Value - Cell Link");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Clear Value - Cell Link");
 
             Row rowA = new Row
             {
@@ -869,7 +869,7 @@ namespace mock_api_test_sdk_net80
                 }
             };
 
-            IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
+            IList<Row> updatedRows = smartsheet.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
 
             Cell updatedCell = updatedRows[0].Cells.Single(c => c.ColumnId == 101);
             Assert.AreEqual(null, updatedCell.LinkInFromCell);
@@ -879,7 +879,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void UpdateRows_ClearValue_PredecessorList()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Update Rows - Clear Value - Predecessor List");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Clear Value - Predecessor List");
 
             Row rowA = new Row
             {
@@ -893,7 +893,7 @@ namespace mock_api_test_sdk_net80
                     }
                 }
             };
-            IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
+            IList<Row> updatedRows = smartsheet.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
             Cell updatedCell = updatedRows[0].Cells.Single(c => c.ColumnId == 123);
             Assert.AreEqual(updatedRows[0].Id, 10);
             Assert.AreEqual(null, updatedCell.Value);
@@ -903,7 +903,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void UpdateRows_Invalid_AssignHyperlinkAndCellLink()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Update Rows - Invalid - Assign Hyperlink and Cell Link");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Invalid - Assign Hyperlink and Cell Link");
 
             Row rowA = new Row
             {
@@ -929,14 +929,14 @@ namespace mock_api_test_sdk_net80
             };
 
             HelperFunctions.AssertRaisesException<SmartsheetException>(() =>
-                    ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA }),
+                    smartsheet.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA }),
                 "Only one of cell.hyperlink or cell.linkInFromCell may be non-null.");
         }
 
         [TestMethod]
         public void UpdateRows_Location_Top()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Update Rows - Location - Top");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Location - Top");
 
             Row rowA = new Row
             {
@@ -944,7 +944,7 @@ namespace mock_api_test_sdk_net80
                 ToTop = true
             };
 
-            IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
+            IList<Row> updatedRows = smartsheet.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
 
             Row updateRow = updatedRows.Single(r => r.Id == 10);
             Assert.AreEqual(1, updateRow.RowNumber);
@@ -953,7 +953,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void UpdateRows_Location_Bottom()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Update Rows - Location - Bottom");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Location - Bottom");
 
             Row rowA = new Row
             {
@@ -961,7 +961,7 @@ namespace mock_api_test_sdk_net80
                 ToBottom = true
             };
 
-            IList<Row> updatedRows = ss.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
+            IList<Row> updatedRows = smartsheet.SheetResources.RowResources.UpdateRows(1, new Row[] { rowA });
 
             Row updateRow = updatedRows.Single(r => r.Id == 10);
             Assert.AreEqual(100, updateRow.RowNumber);
@@ -970,9 +970,9 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void MoveRow_AnotherSheet()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Move row to another sheet");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Move row to another sheet");
 
-            CopyOrMoveRowResult result = ss.SheetResources.RowResources.MoveRowsToAnotherSheet(
+            CopyOrMoveRowResult result = smartsheet.SheetResources.RowResources.MoveRowsToAnotherSheet(
                 1228520367122308,
                 new CopyOrMoveRowDirective
                 {
@@ -991,8 +991,8 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void CopyRow_AnotherSheet()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Copy row to another sheet");
-            CopyOrMoveRowResult result = ss.SheetResources.RowResources.CopyRowsToAnotherSheet(
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Copy row to another sheet");
+            CopyOrMoveRowResult result = smartsheet.SheetResources.RowResources.CopyRowsToAnotherSheet(
                 1228520367122308,
                 new CopyOrMoveRowDirective
                 {

--- a/mock-api-test-sdk-net80/SheetTests.cs
+++ b/mock-api-test-sdk-net80/SheetTests.cs
@@ -10,9 +10,9 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void ListSheets_NoParams()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("List Sheets - No Params");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("List Sheets - No Params");
 
-            PaginatedResult<Sheet> sheets = ss.SheetResources.ListSheets(null, null);
+            PaginatedResult<Sheet> sheets = smartsheet.SheetResources.ListSheets(null, null);
 
             Assert.IsNotNull(sheets.Data.Where(s => s.Name.Equals("Copy of Sample Sheet")).FirstOrDefault());
         }
@@ -20,9 +20,9 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void ListSheets_IncludeOwnerInfo()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("List Sheets - Include Owner Info");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("List Sheets - Include Owner Info");
 
-            PaginatedResult<Sheet> sheets = ss.SheetResources.ListSheets(new List<SheetInclusion> { SheetInclusion.OWNER_INFO });
+            PaginatedResult<Sheet> sheets = smartsheet.SheetResources.ListSheets(new List<SheetInclusion> { SheetInclusion.OWNER_INFO });
 
             Assert.IsNotNull(sheets.Data.Where(s => s.Owner.Equals("john.doe@smartsheet.com")).FirstOrDefault());
         }
@@ -30,7 +30,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void CreateSheet_NoColumns()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Create Sheet - Invalid - No Columns");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Create Sheet - Invalid - No Columns");
 
             Sheet sheetA = new Sheet
             {
@@ -39,7 +39,7 @@ namespace mock_api_test_sdk_net80
             };
 
             HelperFunctions.AssertRaisesException<SmartsheetException>(() =>
-                ss.SheetResources.CreateSheet(sheetA),
+                smartsheet.SheetResources.CreateSheet(sheetA),
                 "The new sheet requires either a fromId or columns.");
         }
     }

--- a/mock-api-test-sdk-net80/SightsTest.cs
+++ b/mock-api-test-sdk-net80/SightsTest.cs
@@ -10,8 +10,8 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void ListSights()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("List Sights");
-            PaginatedResult<Sight> sights = ss.SightResources.ListSights();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("List Sights");
+            PaginatedResult<Sight> sights = smartsheet.SightResources.ListSights();
             Assert.IsNotNull(sights?.TotalCount);
             Assert.AreEqual(6, (long)sights.TotalCount);
         }
@@ -19,8 +19,8 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void GetSight()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Get Sight");
-            Sight sight = ss.SightResources.GetSight(52);
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Get Sight");
+            Sight sight = smartsheet.SightResources.GetSight(52);
             Assert.IsNotNull(sight?.Id);
             Assert.AreEqual(52, (long)sight.Id);
         }
@@ -29,39 +29,39 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void CopySight()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Copy Sight");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Copy Sight");
             ContainerDestination dest = new ContainerDestination();
             dest.DestinationType = DestinationType.FOLDER;
             dest.DestinationId = 424;
             dest.NewName = "new sight";
-            Sight sight = ss.SightResources.CopySight(52, dest);
+            Sight sight = smartsheet.SightResources.CopySight(52, dest);
         }
 
         [TestMethod]
         public void UpdateSight()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Update Sight");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Sight");
             Sight sight = new Sight();
             sight.Id = 812;
             sight.Name = "new new sight";
-            ss.SightResources.UpdateSight(sight);
+            smartsheet.SightResources.UpdateSight(sight);
         }
 
         [TestMethod]
         public void SetPublishStatus()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Set Sight Publish Status");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Set Sight Publish Status");
             SightPublish publish = new SightPublish();
             publish.ReadOnlyFullEnabled = true;
             publish.ReadOnlyFullAccessibleBy = "ALL";
-            ss.SightResources.SetPublishStatus(812, publish);
+            smartsheet.SightResources.SetPublishStatus(812, publish);
         }
 
         [TestMethod]
         public void GetPublishStatus()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Get Sight Publish Status");
-            SightPublish publish = ss.SightResources.GetPublishStatus(812);
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Get Sight Publish Status");
+            SightPublish publish = smartsheet.SightResources.GetPublishStatus(812);
             Assert.IsNotNull(publish.ReadOnlyFullEnabled);
             Assert.IsTrue(publish.ReadOnlyFullEnabled.Value);
         }
@@ -69,8 +69,8 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void DeleteSight()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Delete Sight");
-            ss.SightResources.DeleteSight(700);
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Delete Sight");
+            smartsheet.SightResources.DeleteSight(700);
         }
     }
 }

--- a/mock-api-test-sdk-net80/WorkspaceTests.cs
+++ b/mock-api-test-sdk-net80/WorkspaceTests.cs
@@ -11,10 +11,10 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void GetWorkspaceChildren_NoParams()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Get Workspace Children - No Params");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Get Workspace Children - No Params");
 
             // No params - use minimal required parameters
-            TokenPaginatedResult<object> children = ss.WorkspaceResources.GetWorkspaceChildren(123);
+            TokenPaginatedResult<object> children = smartsheet.WorkspaceResources.GetWorkspaceChildren(123);
 
             Assert.IsNotNull(children);
             Assert.IsNotNull(children.Data);
@@ -50,10 +50,10 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void GetWorkspaceChildren_IncludeSourceAndOwnerInfo()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Get Workspace Children - Include Source and OwnerInfo");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Get Workspace Children - Include Source and OwnerInfo");
 
             // Include source and owner info as specified in scenario title
-            TokenPaginatedResult<object> children = ss.WorkspaceResources.GetWorkspaceChildren(
+            TokenPaginatedResult<object> children = smartsheet.WorkspaceResources.GetWorkspaceChildren(
                 123,
                 null,
                 new List<ChildrenInclusion> { ChildrenInclusion.SOURCE, ChildrenInclusion.OWNER_INFO }
@@ -109,10 +109,10 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void GetWorkspaceChildren_FilterSheetsAndFolders()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Get Workspace Children - Filter Sheets and Folders");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Get Workspace Children - Filter Sheets and Folders");
 
             // Filter to only sheets and folders as specified in scenario title
-            TokenPaginatedResult<object> children = ss.WorkspaceResources.GetWorkspaceChildren(
+            TokenPaginatedResult<object> children = smartsheet.WorkspaceResources.GetWorkspaceChildren(
                 123,
                 new List<ChildrenResourceType> { ChildrenResourceType.FOLDERS, ChildrenResourceType.SHEETS }
             );
@@ -148,10 +148,10 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void GetWorkspaceMetadata_NoParams()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Get Workspace Metadata - No Params");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Get Workspace Metadata - No Params");
 
             // No params - use minimal required parameters
-            Workspace workspace = ss.WorkspaceResources.GetWorkspaceMetadata(123);
+            Workspace workspace = smartsheet.WorkspaceResources.GetWorkspaceMetadata(123);
 
             Assert.IsNotNull(workspace);
             Assert.AreEqual(123, workspace.Id);
@@ -165,10 +165,10 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public void GetWorkspaceMetadata_IncludeSource()
         {
-            SmartsheetClient ss = HelperFunctions.SetupClient("Get Workspace Metadata - Include Source");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Get Workspace Metadata - Include Source");
 
             // Include source as specified in scenario title
-            Workspace workspace = ss.WorkspaceResources.GetWorkspaceMetadata(
+            Workspace workspace = smartsheet.WorkspaceResources.GetWorkspaceMetadata(
                 123,
                 new List<WorkspaceInclusion> { WorkspaceInclusion.SOURCE }
             );

--- a/mock-api-test-sdk-net80/users/TestListUserPlans.cs
+++ b/mock-api-test-sdk-net80/users/TestListUserPlans.cs
@@ -17,9 +17,9 @@ namespace mock_api_test_sdk_net80
         public async Task TestListUserPlansGeneratedUrlIsCorrect()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/users/list-user-plans/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/list-user-plans/all-response-body-properties", requestId.ToString());
             
-            ss.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, TEST_LAST_KEY, TEST_MAX_ITEMS);
+            smartsheet.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, TEST_LAST_KEY, TEST_MAX_ITEMS);
             WiremockHelper wiremockHelper = new WiremockHelper();
             LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
             var uri = new Uri(foundRequest.AbsoluteUrl);
@@ -36,9 +36,9 @@ namespace mock_api_test_sdk_net80
         public void TestListUserPlansAllResponseBodyProperties()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/users/list-user-plans/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/list-user-plans/all-response-body-properties", requestId.ToString());
 
-            TokenPaginatedResult<UserPlan> response = ss.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, TEST_LAST_KEY, TEST_MAX_ITEMS);
+            TokenPaginatedResult<UserPlan> response = smartsheet.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, TEST_LAST_KEY, TEST_MAX_ITEMS);
 
             Assert.IsNotNull(response);
             Assert.AreEqual(TEST_LAST_KEY, response.LastKey);
@@ -53,9 +53,9 @@ namespace mock_api_test_sdk_net80
         public void TestListUserPlansRequiredResponseBodyProperties()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/users/list-user-plans/required-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/list-user-plans/required-response-body-properties", requestId.ToString());
 
-            TokenPaginatedResult<UserPlan> response = ss.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, null, null);
+            TokenPaginatedResult<UserPlan> response = smartsheet.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, null, null);
 
             Assert.IsNotNull(response);
             Assert.AreEqual(CommonTestConstants.TEST_PLAN_ID, response.Data[0].PlanId);
@@ -69,9 +69,9 @@ namespace mock_api_test_sdk_net80
         public void TestListUserPlansError500Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => ss.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, null, null));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, null, null));
             Assert.AreEqual("Internal Server Error", exception.Message);
         }
 
@@ -79,9 +79,9 @@ namespace mock_api_test_sdk_net80
         public void TestListUserPlansError400Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => ss.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, null, null));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, null, null));
             Assert.AreEqual("Malformed Request", exception.Message);
         }
     }

--- a/mock-api-test-sdk-net80/users/TestListUserPlans.cs
+++ b/mock-api-test-sdk-net80/users/TestListUserPlans.cs
@@ -71,7 +71,7 @@ namespace mock_api_test_sdk_net80
             Guid requestId = Guid.NewGuid();
             SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, null, null));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => smartsheet.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, null, null));
             Assert.AreEqual("Internal Server Error", exception.Message);
         }
 
@@ -81,7 +81,7 @@ namespace mock_api_test_sdk_net80
             Guid requestId = Guid.NewGuid();
             SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, null, null));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => smartsheet.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, null, null));
             Assert.AreEqual("Malformed Request", exception.Message);
         }
     }

--- a/mock-api-test-sdk-net80/users/TestListUsers.cs
+++ b/mock-api-test-sdk-net80/users/TestListUsers.cs
@@ -106,7 +106,7 @@ namespace mock_api_test_sdk_net80
             Guid requestId = Guid.NewGuid();
             SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.UserResources.ListUsers(null, CommonTestConstants.TEST_PLAN_ID, null, null));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => smartsheet.UserResources.ListUsers(null, CommonTestConstants.TEST_PLAN_ID, null, null));
             Assert.AreEqual("Internal Server Error", exception.Message);
         }
 
@@ -116,7 +116,7 @@ namespace mock_api_test_sdk_net80
             Guid requestId = Guid.NewGuid();
             SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.UserResources.ListUsers(null, CommonTestConstants.TEST_PLAN_ID, null, null));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => smartsheet.UserResources.ListUsers(null, CommonTestConstants.TEST_PLAN_ID, null, null));
             Assert.AreEqual("Malformed Request", exception.Message);
         }
     }

--- a/mock-api-test-sdk-net80/users/TestListUsers.cs
+++ b/mock-api-test-sdk-net80/users/TestListUsers.cs
@@ -27,11 +27,11 @@ namespace mock_api_test_sdk_net80
         public async Task TestListUsersGeneratedUrlIsCorrect()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/users/list-users/required-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/list-users/required-response-body-properties", requestId.ToString());
 
             PaginationParameters pagination = new PaginationParameters(TEST_INCLUDE_ALL, TEST_PAGE_SIZE, TEST_PAGE);
 
-            ss.UserResources.ListUsers(TEST_EMAILS, CommonTestConstants.TEST_PLAN_ID, TEST_SEAT_TYPE, pagination);
+            smartsheet.UserResources.ListUsers(TEST_EMAILS, CommonTestConstants.TEST_PLAN_ID, TEST_SEAT_TYPE, pagination);
             WiremockHelper wiremockHelper = new WiremockHelper();
             LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
             var uri = new Uri(foundRequest.AbsoluteUrl);
@@ -51,9 +51,9 @@ namespace mock_api_test_sdk_net80
         public async Task TestListUsersAllResponseBodyProperties()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/users/list-users/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/list-users/all-response-body-properties", requestId.ToString());
 
-            PaginatedResult<User> response = ss.UserResources.ListUsers(null, CommonTestConstants.TEST_PLAN_ID, null, null);
+            PaginatedResult<User> response = smartsheet.UserResources.ListUsers(null, CommonTestConstants.TEST_PLAN_ID, null, null);
 
             Assert.IsNotNull(response);
             Assert.AreEqual(TEST_SEAT_TYPE, response.Data[0].SeatType);
@@ -79,9 +79,9 @@ namespace mock_api_test_sdk_net80
         public async Task TestListUsersRequiredResponseBodyProperties()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/users/list-users/required-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/list-users/required-response-body-properties", requestId.ToString());
 
-            PaginatedResult<User> response = ss.UserResources.ListUsers(null, CommonTestConstants.TEST_PLAN_ID, null, null);
+            PaginatedResult<User> response = smartsheet.UserResources.ListUsers(null, CommonTestConstants.TEST_PLAN_ID, null, null);
 
             Assert.IsNotNull(response);
             Assert.AreEqual(TEST_SEAT_TYPE, response.Data[0].SeatType);
@@ -104,9 +104,9 @@ namespace mock_api_test_sdk_net80
         public void TestListUsersError500Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => ss.UserResources.ListUsers(null, CommonTestConstants.TEST_PLAN_ID, null, null));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.UserResources.ListUsers(null, CommonTestConstants.TEST_PLAN_ID, null, null));
             Assert.AreEqual("Internal Server Error", exception.Message);
         }
 
@@ -114,9 +114,9 @@ namespace mock_api_test_sdk_net80
         public void TestListUsersError400Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() => ss.UserResources.ListUsers(null, CommonTestConstants.TEST_PLAN_ID, null, null));
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>smartsheet.UserResources.ListUsers(null, CommonTestConstants.TEST_PLAN_ID, null, null));
             Assert.AreEqual("Malformed Request", exception.Message);
         }
     }

--- a/mock-api-test-sdk-net80/users/TestRemoveUserFromPlan.cs
+++ b/mock-api-test-sdk-net80/users/TestRemoveUserFromPlan.cs
@@ -11,9 +11,9 @@ namespace mock_api_test_sdk_net80
         public async Task TestRemoveUserFromPlanGeneratedUrlIsCorrect()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/users/remove-user-from-plan/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/remove-user-from-plan/all-response-body-properties", requestId.ToString());
 
-            ss.UserResources.RemoveUserFromPlan(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID);
+            smartsheet.UserResources.RemoveUserFromPlan(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID);
             WiremockHelper wiremockHelper = new WiremockHelper();
             LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
             var uri = new Uri(foundRequest.AbsoluteUrl);
@@ -27,20 +27,20 @@ namespace mock_api_test_sdk_net80
         public void TestRemoveUserFromPlanAllResponseBodyProperties()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/users/remove-user-from-plan/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/remove-user-from-plan/all-response-body-properties", requestId.ToString());
 
             // If this throws an exception, the test will fail automatically
-            ss.UserResources.RemoveUserFromPlan(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID);
+            smartsheet.UserResources.RemoveUserFromPlan(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID);
         }
 
         [TestMethod]
         public void TestRemoveUserFromPlanError500Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
 
             SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>
-                ss.UserResources.RemoveUserFromPlan(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID));
+                smartsheet.UserResources.RemoveUserFromPlan(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID));
             
             Assert.IsTrue(exception.Message.Contains("Internal Server Error"));
         }
@@ -49,10 +49,10 @@ namespace mock_api_test_sdk_net80
         public void TestRemoveUserFromPlanError400Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
 
             SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>
-                ss.UserResources.RemoveUserFromPlan(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID));
+                smartsheet.UserResources.RemoveUserFromPlan(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID));
             
             Assert.IsTrue(exception.Message.Contains("Malformed Request"));
         }

--- a/mock-api-test-sdk-net80/users/TestUserDeactivate.cs
+++ b/mock-api-test-sdk-net80/users/TestUserDeactivate.cs
@@ -12,9 +12,9 @@ namespace mock_api_test_sdk_net80
         public async Task TestDeactivateUserGeneratedUrlIsCorrect()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/users/deactivate-user/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/deactivate-user/all-response-body-properties", requestId.ToString());
 
-            ss.UserResources.DeactivateUser(CommonTestConstants.TEST_USER_ID);
+            smartsheet.UserResources.DeactivateUser(CommonTestConstants.TEST_USER_ID);
             WiremockHelper wiremockHelper = new WiremockHelper();
             LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
             var uri = new Uri(foundRequest.AbsoluteUrl);
@@ -27,20 +27,20 @@ namespace mock_api_test_sdk_net80
         public async Task TestDeactivateUserAllResponseBodyProperties()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/users/deactivate-user/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/deactivate-user/all-response-body-properties", requestId.ToString());
 
             // If this throws an exception, the test will fail automatically
-            ss.UserResources.DeactivateUser(CommonTestConstants.TEST_USER_ID);
+            smartsheet.UserResources.DeactivateUser(CommonTestConstants.TEST_USER_ID);
         }
 
         [TestMethod]
         public void TestDeactivateUserError500Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
 
             SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>
-                ss.UserResources.DeactivateUser(CommonTestConstants.TEST_USER_ID));
+                smartsheet.UserResources.DeactivateUser(CommonTestConstants.TEST_USER_ID));
             
             Assert.IsTrue(exception.Message.Contains("Internal Server Error"));
         }
@@ -49,10 +49,10 @@ namespace mock_api_test_sdk_net80
         public void TestDeactivateUserError400Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
 
             SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>
-                ss.UserResources.DeactivateUser(CommonTestConstants.TEST_USER_ID));
+                smartsheet.UserResources.DeactivateUser(CommonTestConstants.TEST_USER_ID));
             
             Assert.IsTrue(exception.Message.Contains("Malformed Request"));
         }

--- a/mock-api-test-sdk-net80/users/TestUserReactivate.cs
+++ b/mock-api-test-sdk-net80/users/TestUserReactivate.cs
@@ -12,9 +12,9 @@ namespace mock_api_test_sdk_net80
         public async Task TestReactivateUserGeneratedUrlIsCorrect()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/users/reactivate-user/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/reactivate-user/all-response-body-properties", requestId.ToString());
 
-            ss.UserResources.ReactivateUser(CommonTestConstants.TEST_USER_ID);
+            smartsheet.UserResources.ReactivateUser(CommonTestConstants.TEST_USER_ID);
             WiremockHelper wiremockHelper = new WiremockHelper();
             LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
             var uri = new Uri(foundRequest.AbsoluteUrl);
@@ -27,20 +27,20 @@ namespace mock_api_test_sdk_net80
         public async Task TestReactivateUserAllResponseBodyProperties()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/users/reactivate-user/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/reactivate-user/all-response-body-properties", requestId.ToString());
 
             // If this throws an exception, the test will fail automatically
-            ss.UserResources.ReactivateUser(CommonTestConstants.TEST_USER_ID);
+            smartsheet.UserResources.ReactivateUser(CommonTestConstants.TEST_USER_ID);
         }
 
         [TestMethod]
         public void TestReactivateUserError500Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
 
             SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>
-                ss.UserResources.ReactivateUser(CommonTestConstants.TEST_USER_ID));
+                smartsheet.UserResources.ReactivateUser(CommonTestConstants.TEST_USER_ID));
             
             Assert.IsTrue(exception.Message.Contains("Internal Server Error"));
         }
@@ -49,10 +49,10 @@ namespace mock_api_test_sdk_net80
         public void TestReactivateUserError400Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
 
             SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>
-                ss.UserResources.ReactivateUser(CommonTestConstants.TEST_USER_ID));
+                smartsheet.UserResources.ReactivateUser(CommonTestConstants.TEST_USER_ID));
             
             Assert.IsTrue(exception.Message.Contains("Malformed Request"));
         }

--- a/mock-api-test-sdk-net80/users/TestUserUpgradeDowngrade.cs
+++ b/mock-api-test-sdk-net80/users/TestUserUpgradeDowngrade.cs
@@ -15,9 +15,9 @@ namespace mock_api_test_sdk_net80
         public async Task TestUpgradeUserGeneratedUrlIsCorrect()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/users/upgrade-user/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/upgrade-user/all-response-body-properties", requestId.ToString());
 
-            ss.UserResources.UpgradeUser(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID, TEST_UPGRADE_SEAT_TYPE);
+            smartsheet.UserResources.UpgradeUser(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID, TEST_UPGRADE_SEAT_TYPE);
             WiremockHelper wiremockHelper = new WiremockHelper();
             LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
             var uri = new Uri(foundRequest.AbsoluteUrl);
@@ -31,10 +31,10 @@ namespace mock_api_test_sdk_net80
         public async Task TestUpgradeUserAllResponseBodyProperties()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/users/upgrade-user/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/upgrade-user/all-response-body-properties", requestId.ToString());
 
             // If this throws an exception, the test will fail automatically
-            ss.UserResources.UpgradeUser(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID, TEST_UPGRADE_SEAT_TYPE);
+            smartsheet.UserResources.UpgradeUser(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID, TEST_UPGRADE_SEAT_TYPE);
 
             WiremockHelper wiremockHelper = new WiremockHelper();
             LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
@@ -47,20 +47,20 @@ namespace mock_api_test_sdk_net80
         public void TestUpgradeUserNoSeatType()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/users/upgrade-user/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/upgrade-user/all-response-body-properties", requestId.ToString());
 
             // If this throws an exception, the test will fail automatically
-            ss.UserResources.UpgradeUser(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID, null);
+            smartsheet.UserResources.UpgradeUser(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID, null);
         }
 
         [TestMethod]
         public void TestUpgradeUserError500Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
 
             SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>
-                ss.UserResources.UpgradeUser(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID, TEST_UPGRADE_SEAT_TYPE));
+                smartsheet.UserResources.UpgradeUser(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID, TEST_UPGRADE_SEAT_TYPE));
             
             Assert.IsTrue(exception.Message.Contains("Internal Server Error"));
         }
@@ -69,10 +69,10 @@ namespace mock_api_test_sdk_net80
         public void TestUpgradeUserError400Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
 
             SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>
-                ss.UserResources.UpgradeUser(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID, TEST_UPGRADE_SEAT_TYPE));
+                smartsheet.UserResources.UpgradeUser(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID, TEST_UPGRADE_SEAT_TYPE));
             
             Assert.IsTrue(exception.Message.Contains("Malformed Request"));
         }
@@ -81,9 +81,9 @@ namespace mock_api_test_sdk_net80
         public async Task TestDowngradeUserGeneratedUrlIsCorrect()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/users/downgrade-user/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/downgrade-user/all-response-body-properties", requestId.ToString());
 
-            ss.UserResources.DowngradeUser(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID, TEST_DOWNGRADE_SEAT_TYPE);
+            smartsheet.UserResources.DowngradeUser(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID, TEST_DOWNGRADE_SEAT_TYPE);
             WiremockHelper wiremockHelper = new WiremockHelper();
             LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
             var uri = new Uri(foundRequest.AbsoluteUrl);
@@ -97,10 +97,10 @@ namespace mock_api_test_sdk_net80
         public async Task TestDowngradeUserAllResponseBodyProperties()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/users/downgrade-user/all-response-body-properties", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/downgrade-user/all-response-body-properties", requestId.ToString());
 
             // If this throws an exception, the test will fail automatically
-            ss.UserResources.DowngradeUser(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID, TEST_DOWNGRADE_SEAT_TYPE);
+            smartsheet.UserResources.DowngradeUser(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID, TEST_DOWNGRADE_SEAT_TYPE);
 
             WiremockHelper wiremockHelper = new WiremockHelper();
             LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
@@ -113,10 +113,10 @@ namespace mock_api_test_sdk_net80
         public void TestDowngradeUserError500Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
 
             SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>
-                ss.UserResources.DowngradeUser(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID, TEST_DOWNGRADE_SEAT_TYPE));
+                smartsheet.UserResources.DowngradeUser(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID, TEST_DOWNGRADE_SEAT_TYPE));
             
             Assert.IsTrue(exception.Message.Contains("Internal Server Error"));
         }
@@ -125,10 +125,10 @@ namespace mock_api_test_sdk_net80
         public void TestDowngradeUserError400Response()
         {
             Guid requestId = Guid.NewGuid();
-            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
 
             SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>
-                ss.UserResources.DowngradeUser(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID, TEST_DOWNGRADE_SEAT_TYPE));
+                smartsheet.UserResources.DowngradeUser(CommonTestConstants.TEST_USER_ID, CommonTestConstants.TEST_PLAN_ID, TEST_DOWNGRADE_SEAT_TYPE));
             
             Assert.IsTrue(exception.Message.Contains("Malformed Request"));
         }


### PR DESCRIPTION
Refactoring to change the variable used for the smartsheet client within tests and documentation due to internal policy