### PR TITLE
Remove redundant http client and json serializer creation.

### DIFF
--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/SmartsheetBuilder.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/SmartsheetBuilder.cs
@@ -302,18 +302,6 @@ namespace Smartsheet.Api
                     Environment.GetEnvironmentVariable(SMARTSHEET_ACCESS_TOKEN, EnvironmentVariableTarget.Machine);
             }
 
-            // Create default HttpClient if none is provided
-            if (httpClient == null)
-            {
-                httpClient = new DefaultHttpClient();
-            }
-
-            // Create default JsonSerializer if none is provided
-            if (jsonSerializer == null)
-            {
-                jsonSerializer = new JsonNetSerializer();
-            }
-
             SmartsheetImpl smartsheet = new SmartsheetImpl(baseURI, accessToken, httpClient, jsonSerializer, dateTimeFixOptOut, enableDecimalObjectValue);
 
             if (changeAgent != null)


### PR DESCRIPTION
## Summary

Fixes #168 — removes redundant default `HttpClient` and `JsonSerializer` instantiation from `SmartsheetBuilder.Build()`, since `SmartsheetImpl`'s constructor already handles `null` for both parameters and creates properly configured defaults.

## Problem

`SmartsheetBuilder.Build()` was pre-emptively creating default instances before passing them to `SmartsheetImpl`:

```csharp
// Create default HttpClient if none is provided
if (httpClient == null)
{
    httpClient = new DefaultHttpClient();
}

// Create default JsonSerializer if none is provided
if (jsonSerializer == null)
{
    jsonSerializer = new JsonNetSerializer();
}