### PR TITLE
feat(events): add ObjectIdStr property to Event model with WireMock t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [X.X.X] - Unreleased
 
 ### Added
+- Added `ObjectIdStr` property to `Event` model to support alphanumeric object identifiers (AUD-905)
 - AI assisted workflows via claude skills (`implement-api-endpoint` and `review-api-endpoint`).
 
 ## [6.7.0] - 2026-04-30

--- a/mock-api-test-sdk-net80/events/TestListEvents.cs
+++ b/mock-api-test-sdk-net80/events/TestListEvents.cs
@@ -1,0 +1,238 @@
+using Newtonsoft.Json;
+using System.Globalization;
+using System.Web;
+using Smartsheet.Api;
+using Smartsheet.Api.Models;
+
+namespace mock_api_test_sdk_net80
+{
+    [TestClass]
+    public class TestListEvents
+    {
+        private const string NEXT_STREAM_POSITION = "2.1.Y-oF8RMroSCo4WLS9p78QEz-LXzzzzzzjnXA2hFnCN_w";
+        private const string SINCE_STRING = "2024-05-06T00:00:00Z";
+        private static readonly DateTime SINCE = DateTime.Parse(SINCE_STRING, null, DateTimeStyles.RoundtripKind);
+
+        private static readonly EventResult EXPECTED_ALL_RESPONSE = new EventResult
+        {
+            MoreAvailable = true,
+            NextStreamPosition = NEXT_STREAM_POSITION,
+            Data = new List<Event>
+            {
+                new Event
+                {
+                    EventId = "4f12345678901234",
+                    ObjectType = EventObjectType.SHEET,
+                    ObjectId = 1234567890123456L,
+                    ObjectIdStr = "1234567890123456",
+                    UserId = 12345678L,
+                    RequestUserId = 12345678L,
+                    EventTimestamp = "2024-05-06T10:30:00Z",
+                    Action = EventAction.UPDATE,
+                    Source = EventSource.WEB_APP,
+                    AdditionalDetails = new Dictionary<string, object> { { "emailAddress", "test@test.com" } }
+                },
+                new Event
+                {
+                    EventId = "4f12345678901235",
+                    ObjectType = EventObjectType.WORKSPACE,
+                    ObjectId = 9876543210987654L,
+                    ObjectIdStr = "9876543210987654",
+                    UserId = 12345679L,
+                    RequestUserId = 12345679L,
+                    EventTimestamp = "2024-05-06T09:15:00Z",
+                    Action = EventAction.CREATE,
+                    Source = EventSource.API_UNDEFINED_APP,
+                    AdditionalDetails = new Dictionary<string, object> { { "emailAddress", "test@test.com" } }
+                },
+                new Event
+                {
+                    EventId = "2.1.Y-oF8RMroSCo4WLS9p78QEz-LXxxxyyyjnXA2hFnCN_w",
+                    ObjectType = EventObjectType.SHEET,
+                    Action = EventAction.PURGE,
+                    ObjectId = 3573510329814916L,
+                    ObjectIdStr = "3573510329814916",
+                    EventTimestamp = "2024-05-06T09:09:33Z",
+                    UserId = 12345678L,
+                    RequestUserId = 12345678L,
+                    Source = EventSource.UNKNOWN,
+                    AdditionalDetails = new Dictionary<string, object> { { "emailAddress", "test@test.com" } }
+                },
+                new Event
+                {
+                    EventId = "2.1.SuwpcrfUcr75nP591Hce4_zQxxxyyy_0CDfvRRx6V0",
+                    ObjectType = EventObjectType.ATTACHMENT,
+                    Action = EventAction.CREATE,
+                    ObjectId = 4230707048648580L,
+                    ObjectIdStr = "4230707048648580",
+                    EventTimestamp = "2024-05-06T10:30:00Z",
+                    UserId = 12345678L,
+                    RequestUserId = 12345678L,
+                    Source = EventSource.UNKNOWN,
+                    AdditionalDetails = new Dictionary<string, object>
+                    {
+                        { "emailAddress", "test@test.com" },
+                        { "sheetId", "102030405" },
+                        { "attachmentName", "picture.jpg" }
+                    }
+                },
+                new Event
+                {
+                    EventId = "2.1.ifR6WlBin9DQVYHDkQEx1D3EAxxxyyyXtcLWa9Oio",
+                    ObjectType = EventObjectType.SHEET,
+                    Action = EventAction.LOAD,
+                    ObjectId = 8462951303303044L,
+                    ObjectIdStr = "8462951303303044",
+                    EventTimestamp = "2024-05-06T10:35:15Z",
+                    UserId = 8737233684457348L,
+                    RequestUserId = 8737233684457348L,
+                    Source = EventSource.API_INTEGRATED_APP,
+                    AdditionalDetails = new Dictionary<string, object> { { "emailAddress", "test@test.com" } }
+                }
+            }
+        };
+
+        private static readonly EventResult EXPECTED_REQUIRED_RESPONSE = new EventResult
+        {
+            MoreAvailable = false,
+            Data = new List<Event>
+            {
+                new Event
+                {
+                    EventId = "4f12345678901234",
+                    ObjectType = EventObjectType.SHEET,
+                    ObjectId = 1234567890123456L,
+                    UserId = 12345678L,
+                    RequestUserId = 12345678L,
+                    EventTimestamp = "2024-05-06T10:30:00Z",
+                    Action = EventAction.UPDATE,
+                    Source = EventSource.WEB_APP
+                },
+                new Event
+                {
+                    EventId = "4f12345678901235",
+                    ObjectType = EventObjectType.WORKSPACE,
+                    ObjectId = 9876543210987654L,
+                    UserId = 12345679L,
+                    RequestUserId = 12345679L,
+                    EventTimestamp = "2024-05-06T09:15:00Z",
+                    Action = EventAction.CREATE,
+                    Source = EventSource.API_UNDEFINED_APP
+                },
+                new Event
+                {
+                    EventId = "2.1.Y-oF8RMroSCo4WLS9p78QEz-LXxxxyyyjnXA2hFnCN_w",
+                    ObjectType = EventObjectType.SHEET,
+                    Action = EventAction.PURGE,
+                    ObjectId = 3573510329814916L,
+                    EventTimestamp = "2024-05-06T09:09:33Z",
+                    UserId = 12345678L,
+                    RequestUserId = 12345678L,
+                    Source = EventSource.UNKNOWN
+                },
+                new Event
+                {
+                    EventId = "2.1.SuwpcrfUcr75nP591Hce4_zQxxxyyy_0CDfvRRx6V0",
+                    ObjectType = EventObjectType.ATTACHMENT,
+                    Action = EventAction.CREATE,
+                    ObjectId = 4230707048648580L,
+                    EventTimestamp = "2024-05-06T10:30:00Z",
+                    UserId = 12345678L,
+                    RequestUserId = 12345678L,
+                    Source = EventSource.UNKNOWN
+                },
+                new Event
+                {
+                    EventId = "2.1.ifR6WlBin9DQVYHDkQEx1D3EAxxxyyyXtcLWa9Oio",
+                    ObjectType = EventObjectType.SHEET,
+                    Action = EventAction.LOAD,
+                    ObjectId = 8462951303303044L,
+                    EventTimestamp = "2024-05-06T10:35:15Z",
+                    UserId = 8737233684457348L,
+                    RequestUserId = 8737233684457348L,
+                    Source = EventSource.API_INTEGRATED_APP
+                }
+            }
+        };
+
+        [TestMethod]
+        public async Task TestListEventsGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/events/list-events/all-response-body-properties", requestId.ToString());
+
+            smartsheet.EventResources.ListEvents(SINCE, null, null, null);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+
+            Assert.AreEqual("/2.0/events", uri.AbsolutePath);
+            Assert.AreEqual("GET", foundRequest.Method);
+
+            var queryParams = HttpUtility.ParseQueryString(uri.Query);
+            CollectionAssert.AreEquivalent(
+                new Dictionary<string, string> { { "since", SINCE_STRING } },
+                queryParams.AllKeys.ToDictionary(k => k, k => queryParams[k])
+            );
+        }
+
+        [TestMethod]
+        public async Task TestListEventsAllResponseBodyProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/events/list-events/all-response-body-properties", requestId.ToString());
+
+            EventResult result = smartsheet.EventResources.ListEvents(null, null, null, null);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsTrue(string.IsNullOrEmpty(foundRequest.Body));
+            Assert.AreEqual(JsonConvert.SerializeObject(EXPECTED_ALL_RESPONSE), JsonConvert.SerializeObject(result));
+        }
+
+        [TestMethod]
+        public async Task TestListEventsRequiredResponseBodyProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/events/list-events/required-response-body-properties", requestId.ToString());
+
+            EventResult result = smartsheet.EventResources.ListEvents(null, null, null, null);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsTrue(string.IsNullOrEmpty(foundRequest.Body));
+            Assert.AreEqual(JsonConvert.SerializeObject(EXPECTED_REQUIRED_RESPONSE), JsonConvert.SerializeObject(result));
+        }
+
+        [TestMethod]
+        public void TestListEventsError400Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>
+                smartsheet.EventResources.ListEvents(null, null, null, null)
+            );
+
+            Assert.IsTrue(exception.Message.Contains("Malformed Request"));
+        }
+
+        [TestMethod]
+        public void TestListEventsError500Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>
+                smartsheet.EventResources.ListEvents(null, null, null, null)
+            );
+
+            Assert.IsTrue(exception.Message.Contains("Internal Server Error"));
+        }
+    }
+}

--- a/mock-api-test-sdk-net80/events/TestListEvents.cs
+++ b/mock-api-test-sdk-net80/events/TestListEvents.cs
@@ -161,7 +161,7 @@ namespace mock_api_test_sdk_net80
             Guid requestId = Guid.NewGuid();
             SmartsheetClient smartsheet = HelperFunctions.SetupClient("/events/list-events/all-response-body-properties", requestId.ToString());
 
-            smartsheet.EventResources.ListEvents(SINCE, null, 100, false);
+            smartsheet.EventResources.ListEvents(SINCE, NEXT_STREAM_POSITION, 100, false);
 
             WiremockHelper wiremockHelper = new WiremockHelper();
             LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
@@ -177,6 +177,7 @@ namespace mock_api_test_sdk_net80
                 new Dictionary<string, string>
                 {
                     { "since", SINCE_STRING },
+                    { "streamPosition", NEXT_STREAM_POSITION },
                     { "maxCount", "100" },
                     { "numericDates", "False" }
                 },

--- a/mock-api-test-sdk-net80/events/TestListEvents.cs
+++ b/mock-api-test-sdk-net80/events/TestListEvents.cs
@@ -161,7 +161,7 @@ namespace mock_api_test_sdk_net80
             Guid requestId = Guid.NewGuid();
             SmartsheetClient smartsheet = HelperFunctions.SetupClient("/events/list-events/all-response-body-properties", requestId.ToString());
 
-            smartsheet.EventResources.ListEvents(SINCE, null, null, null);
+            smartsheet.EventResources.ListEvents(SINCE, null, 100, false);
 
             WiremockHelper wiremockHelper = new WiremockHelper();
             LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
@@ -174,7 +174,12 @@ namespace mock_api_test_sdk_net80
 
             var queryParams = HttpUtility.ParseQueryString(uri.Query);
             CollectionAssert.AreEquivalent(
-                new Dictionary<string, string> { { "since", SINCE_STRING } },
+                new Dictionary<string, string>
+                {
+                    { "since", SINCE_STRING },
+                    { "maxCount", "100" },
+                    { "numericDates", "False" }
+                },
                 queryParams.AllKeys.ToDictionary(k => k, k => queryParams[k])
             );
         }

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Event.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Event.cs
@@ -56,6 +56,12 @@ namespace Smartsheet.Api.Models
         private object objectId;
 
         /// <summary>
+        /// The alphanumeric identifier of the object impacted by the event.
+        /// Present for object types that use string-based identifiers.
+        /// </summary>
+        private string objectIdStr;
+
+        /// <summary>
         /// The Smartsheet resource impacted by the event
         /// </summary>
         private EventObjectType objectType;
@@ -132,6 +138,17 @@ namespace Smartsheet.Api.Models
         {
             get { return objectId; }
             set { objectId = value; }
+        }
+
+        /// <summary>
+        /// Gets the alphanumeric identifier of the object impacted by the event.
+        /// Present for object types that use string-based identifiers.
+        /// </summary>
+        /// <returns>the alphanumeric object ID string, or null if not present</returns>
+        public string ObjectIdStr
+        {
+            get { return objectIdStr; }
+            set { objectIdStr = value; }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
 
Adds the optional `ObjectIdStr` property to the `Event` class in the Smartsheet C# SDK to support alphanumeric object identifiers. This mirrors the implementation already done in [smartsheet-java-sdk](https://github.com/smartsheet/smartsheet-java-sdk), [smartsheet-javascript-sdk](https://github.com/smartsheet/smartsheet-javascript-sdk), and [smartsheet-python-sdk](https://github.com/smartsheet/smartsheet-python-sdk).
 
## Changes
 
- Added `ObjectIdStr` property to `Event` class in `smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Event.cs` with XML documentation
- Added WireMock integration tests for the `ListEvents` endpoint (`mock-api-test-sdk-net80/events/`)
- Updated `CHANGELOG.md`
## Testing
 
WireMock integration tests cover:
- URL and query parameter correctness
- Full response body (with `ObjectIdStr`)
- Required-only response body (without `ObjectIdStr`, confirming backward compatibility)
- 400 and 500 error handling
Start WireMock (`docker compose up` in `smartsheet-sdk-tests`), then run:
```
dotnet test mock-api-test-sdk-net80/mock-api-test-sdk-net80.csproj --filter "FullyQualifiedName~TestListEvents"
```