### PR TITLE
Feat: Add async methods/overrides

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -466,7 +466,7 @@ public async virtual Task<bool> ShouldRetryAsync(int previousAttempts, long tota
         case 4002:  // Concurrent update conflict
         case 4003:  // Temporary unavailability
         case 4004:  // System maintenance
-            return await RetrySleep(previousAttempts, totalElapsedTime, response.StatusCode, null, cancellationToken).ConfigureAwait(false);
+            return await RetrySleep(previousAttempts, totalElapsedTime, response.StatusCode, error, cancellationToken).ConfigureAwait(false);
         default:
             return false;  // Non-retryable error
     }

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -336,13 +336,13 @@ Cross-references: Exception throwing integrates with [Response Handling](#respon
 
 ### Retry Logic and Backoff
 
-The SDK implements automatic retry logic with exponential backoff for transient failures, handling rate limiting and temporary server errors transparently within `DefaultHttpClient.RequestAsync()` (`DefaultHttpClient.cs:249-345`). The retry mechanism evaluates error conditions, calculates progressive delay intervals, enforces timeout boundaries, and logs retry attempts at INFO level for operational visibility.
+The SDK implements automatic retry logic with exponential backoff for transient failures, handling rate limiting and temporary server errors transparently within `DefaultHttpClient.RequestAsync()` (`DefaultHttpClient.cs:221-316`). The retry mechanism evaluates error conditions, calculates progressive delay intervals, enforces timeout boundaries, and logs retry attempts at INFO level for operational visibility.
 
-Retry eligibility determination occurs in `ShouldRetry()` method (`DefaultHttpClient.cs:426-474`), which classifies errors into retryable and non-retryable categories. Retryable conditions include HTTP status codes (429 Too Many Requests, 502 Bad Gateway, 503 Service Unavailable) and Smartsheet-specific error codes (4001-4004 indicating rate limiting, concurrent updates, or temporary unavailability). Non-retryable errors encompass client mistakes (400 Bad Request, 401 Unauthorized, 404 Not Found) and SDK-specific 1xxx error codes signaling invalid parameters or malformed requests that cannot succeed upon retry. Status code evaluation precedes JSON parsing: HTTP 429, 502, 503 trigger immediate retry without inspecting response body, while other non-200 codes require JSON deserialization to extract `ErrorCode` property for granular classification. Content-Type validation (`contentType.StartsWith("application/json")`) prevents parse exceptions on HTML error pages from proxies or load balancers, treating non-JSON responses as non-retryable to avoid indefinite retry loops on infrastructure failures.
+Retry eligibility determination occurs in `ShouldRetry()` for sync requests, and `ShouldRetryAsync()` for async methods (`DefaultHttpClient.cs:397-458`), both of which classify errors into retryable and non-retryable categories. Retryable conditions include HTTP status codes (429 Too Many Requests, 502 Bad Gateway, 503 Service Unavailable) and Smartsheet-specific error codes (4001-4004 indicating rate limiting, concurrent updates, or temporary unavailability). Non-retryable errors encompass client mistakes (400 Bad Request, 401 Unauthorized, 404 Not Found) and SDK-specific 1xxx error codes signaling invalid parameters or malformed requests that cannot succeed upon retry. Status code evaluation precedes JSON parsing: HTTP 429, 502, 503 trigger immediate retry without inspecting response body, while other non-200 codes require JSON deserialization to extract `ErrorCode` property for granular classification. Content-Type validation (`contentType.StartsWith("application/json")`) prevents parse exceptions on HTML error pages from proxies or load balancers, treating non-JSON responses as non-retryable to avoid indefinite retry loops on infrastructure failures.
 
-Backoff calculation follows exponential delay pattern in `CalcBackoff()` method (`DefaultHttpClient.cs:406-416`), computing wait time as `2^attempt * 1000ms + random(0-1000ms)`. The exponential base doubles delay with each attempt (1st retry ~2 seconds, 2nd ~4 seconds, 3rd ~8 seconds), while jitter component adds randomness to prevent synchronized retry storms when multiple clients encounter rate limits simultaneously. For example, third retry attempt calculates `2^3 * 1000 + 500 = 8500ms` backoff assuming 500ms random jitter. `MaxRetryTimeout` enforcement (default 15000ms, configurable via `SmartsheetBuilder.SetMaxRetryTimeout()`) bounds total elapsed time: `CalcBackoff()` returns -1 when `totalElapsedTime + backoffMillis > maxRetryTimeout`, signaling retry loop termination and exception propagation to caller. This timeout represents cumulative request duration including all retry delays, not per-attempt limit, ensuring predictable worst-case latency for API operations.
+Backoff calculation follows exponential delay pattern in `CalcBackoff()` method (`DefaultHttpClient.cs:377-387`), computing wait time as `2^attempt * 1000ms + random(0-1000ms)`. The exponential base doubles delay with each attempt (1st retry ~2 seconds, 2nd ~4 seconds, 3rd ~8 seconds), while jitter component adds randomness to prevent synchronized retry storms when multiple clients encounter rate limits simultaneously. For example, third retry attempt calculates `2^3 * 1000 + 500 = 8500ms` backoff assuming 500ms random jitter. `MaxRetryTimeout` enforcement (default 15000ms, configurable via `SmartsheetBuilder.SetMaxRetryTimeout()`) bounds total elapsed time: `CalcBackoff()` returns -1 when `totalElapsedTime + backoffMillis > maxRetryTimeout`, signaling retry loop termination and exception propagation to caller. This timeout represents cumulative request duration including all retry delays, not per-attempt limit, ensuring predictable worst-case latency for API operations.
 
-The retry loop in `RequestAsync()` (`DefaultHttpClient.cs:263-344`) executes HTTP requests within `while (true)` construct, evaluating response after each attempt. Success path (HTTP 200) breaks immediately, returning response to caller without retry overhead. Non-200 responses invoke `ShouldRetry(++attempt, totalElapsed.ElapsedMilliseconds, smartsheetResponse)`, passing incremented attempt counter and stopwatch-tracked elapsed time. When `ShouldRetry()` returns true, control flow remains in loop, reconstructing `RestRequest` and re-executing HTTP transmission with identical parameters. When `ShouldRetry()` returns false (non-retryable error or timeout exceeded), loop exits via `break` statement, delegating error response to resource method's `HandleError()` for exception construction (see [Error Handling and Exceptions](#error-handling-and-exceptions)). Thread sleep occurs within `RetrySleep()` helper method (`DefaultHttpClient.cs:484-493`), which invokes `CalcBackoff()`, logs retry attempt at INFO level, and calls `Thread.Sleep(TimeSpan.FromMilliseconds(backoff))` to delay execution before next attempt.
+The retry loop in `RequestAsync()` (`DefaultHttpClient.cs:221-316`) executes HTTP requests within `while (true)` construct, evaluating response after each attempt. Success path (HTTP 200) breaks immediately, returning response to caller without retry overhead. Non-200 responses invoke `ShouldRetryAsync(++attempt, totalElapsed.ElapsedMilliseconds, smartsheetResponse, cancellationToken)`, passing incremented attempt counter and stopwatch-tracked elapsed time. When `ShouldRetryAsync()` returns true, control flow remains in loop, reconstructing `RestRequest` and re-executing HTTP transmission with identical parameters. When `ShouldRetryAsync()` returns false (non-retryable error or timeout exceeded), loop exits via `break` statement, delegating error response to resource method's `HandleError()` for exception construction (see [Error Handling and Exceptions](#error-handling-and-exceptions)). Thread sleep occurs within `RetrySleep()` helper method (`DefaultHttpClient.cs:469-478`), which invokes `CalcBackoff()`, logs retry attempt at INFO level, and calls `Task.Delay(TimeSpan.FromMilliseconds(backoff), cancellationToken)` to delay execution before next attempt.
 
 ```
 Execute Request
@@ -377,11 +377,11 @@ Check Status
                  └─ Retry Request (loop)
 ```
 
-Custom retry behavior extends via method overrides in `DefaultHttpClient` subclass. Override `ShouldRetry()` to modify retry eligibility (e.g., adding custom error codes to retryable set), override `CalcBackoff()` to implement alternative delay strategies (linear backoff, fixed intervals, API-provided Retry-After header inspection), or override both for comprehensive control. Example implementation in [Overriding HTTP Client Behavior](#overriding-http-client-behavior) demonstrates adding fictional error code 9999 to retryable conditions while preserving default exponential backoff calculation. Virtual method pattern enables selective customization: subclass calls `base.CalcBackoff()` or `base.ShouldRetry()` to delegate to default implementation for standard cases, overriding logic only for specialized requirements.
+Custom retry behavior extends via method overrides in `DefaultHttpClient` subclass. Override `ShouldRetryAsync()` to modify retry eligibility (e.g., adding custom error codes to retryable set), override `CalcBackoff()` to implement alternative delay strategies (linear backoff, fixed intervals, API-provided Retry-After header inspection), or override both for comprehensive control. Example implementation in [Overriding HTTP Client Behavior](#overriding-http-client-behavior) demonstrates adding fictional error code 9999 to retryable conditions while preserving default exponential backoff calculation. Virtual method pattern enables selective customization: subclass calls `base.CalcBackoff()` or `base.ShouldRetryAsync()` to delegate to default implementation for standard cases, overriding logic only for specialized requirements.
 
 ```csharp
 // DefaultHttpClient.cs - Retry loop with status evaluation
-private async Task<HttpResponse> RequestAsync(HttpRequest smartsheetRequest)
+private async Task<HttpResponse> RequestAsync(HttpRequest smartsheetRequest, CancellationToken cancellationToken)
 {
     int attempt = 0;
     HttpResponse smartsheetResponse = null;
@@ -399,9 +399,7 @@ private async Task<HttpResponse> RequestAsync(HttpRequest smartsheetRequest)
         
         Stopwatch timer = new Stopwatch();
         timer.Start();
-        Task<RestResponse> restResponseAsTask = this.httpClient.ExecuteAsync(restRequest);
-        restResponseAsTask.Wait();
-        restResponse = restResponseAsTask.Result;
+        RestResponse restResponseAsTask = await this.httpClient.ExecuteAsync(restRequest, cancellationToken).ConfigureAwait(false);
         timer.Stop();
         
         // Convert RestResponse to HttpResponse (lines 306-325)
@@ -419,7 +417,8 @@ private async Task<HttpResponse> RequestAsync(HttpRequest smartsheetRequest)
         }
         
         // Evaluate retry eligibility for non-OK responses
-        if (!ShouldRetry(++attempt, totalElapsed.ElapsedMilliseconds, smartsheetResponse))
+        bool shouldRetry = await ShouldRetryAsync(++attempt, totalElapsed.ElapsedMilliseconds, smartsheetResponse, cancellationToken).ConfigureAwait(false);
+        if (!shouldRetry)
         {
             break;  // Exit loop, return error for exception handling
         }
@@ -430,7 +429,7 @@ private async Task<HttpResponse> RequestAsync(HttpRequest smartsheetRequest)
 }
 
 // DefaultHttpClient.cs - Retry eligibility evaluation
-public virtual bool ShouldRetry(int previousAttempts, long totalElapsedTime, HttpResponse response)
+public async virtual Task<bool> ShouldRetryAsync(int previousAttempts, long totalElapsedTime, HttpResponse response, CancellationToken cancellationToken)
 {
     // Status code-based retry (no JSON parsing required)
     switch (response.StatusCode)
@@ -438,7 +437,7 @@ public virtual bool ShouldRetry(int previousAttempts, long totalElapsedTime, Htt
         case TooManyRequests:  // HTTP 429
         case HttpStatusCode.BadGateway:  // HTTP 502
         case HttpStatusCode.ServiceUnavailable:  // HTTP 503
-            return RetrySleep(previousAttempts, totalElapsedTime, response.StatusCode, null);
+            return await RetrySleep(previousAttempts, totalElapsedTime, response.StatusCode, null, cancellationToken).ConfigureAwait(false);
     }
     
     // Validate JSON content type before parsing
@@ -467,7 +466,7 @@ public virtual bool ShouldRetry(int previousAttempts, long totalElapsedTime, Htt
         case 4002:  // Concurrent update conflict
         case 4003:  // Temporary unavailability
         case 4004:  // System maintenance
-            return RetrySleep(previousAttempts, totalElapsedTime, response.StatusCode, error);
+            return await RetrySleep(previousAttempts, totalElapsedTime, response.StatusCode, null, cancellationToken).ConfigureAwait(false);
         default:
             return false;  // Non-retryable error
     }
@@ -489,7 +488,7 @@ public virtual long CalcBackoff(int previousAttempts, long totalElapsedTime, Api
 }
 
 // DefaultHttpClient.cs - Backoff execution with logging
-public virtual bool RetrySleep(int previousAttempts, long totalElapsedTime, HttpStatusCode statusCode, Api.Models.Error error)
+public async virtual Task<bool> RetrySleep(int previousAttempts, long totalElapsedTime, HttpStatusCode statusCode, Api.Models.Error error, CancellationToken cancellationToken)
 {
     long backoff = CalcBackoff(previousAttempts, totalElapsedTime, error);
     if (backoff < 0)
@@ -497,7 +496,7 @@ public virtual bool RetrySleep(int previousAttempts, long totalElapsedTime, Http
     
     // Log retry attempt at INFO level for operational visibility
     logger.Info(string.Format("HttpError StatusCode={0}: Retrying in {1} milliseconds", statusCode, backoff));
-    Thread.Sleep(TimeSpan.FromMilliseconds(backoff));
+    await Task.Delay(TimeSpan.FromMilliseconds(backoff), cancellationToken).ConfigureAwait(false);
     return true;
 }
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - ⚠️ **BREAKING**: Change `DefaultHttpClient.RetrySleep()` into an async method that returns a boolean wrapped in a Task
-- ⚠️ **BREAKING**: Add `HttpClient.RequestAsync()` which must be overridden in custom HttpClient implementations to affect async resource methods
+- ⚠️ **BREAKING**: Add `RequestAsync()` to `HttpClient` interface, which must be overridden in custom HttpClient implementations to affect async resource methods
 
 ## [6.7.0] - 2026-04-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - ⚠️ **BREAKING**: Change `DefaultHttpClient.RetrySleep()` into an async method that returns a boolean wrapped in a Task
+- ⚠️ **BREAKING**: Add `DefaultHttpClient.RequestAsync()` which must be overridden in custom HttpClient implementations to affect async resource methods
 
 ## [6.7.0] - 2026-04-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - ⚠️ **BREAKING**: Change `DefaultHttpClient.RetrySleep()` into an async method that returns a boolean wrapped in a Task
-- ⚠️ **BREAKING**: Add `DefaultHttpClient.RequestAsync()` which must be overridden in custom HttpClient implementations to affect async resource methods
+- ⚠️ **BREAKING**: Add `HttpClient.RequestAsync()` which must be overridden in custom HttpClient implementations to affect async resource methods
 
 ## [6.7.0] - 2026-04-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - AI assisted workflows via claude skills (`implement-api-endpoint` and `review-api-endpoint`).
 
+### Changed
+- ⚠️ **BREAKING**: Change `DefaultHttpClient.RetrySleep()` into an async method that returns a boolean wrapped in a Task
+
 ## [6.7.0] - 2026-04-30
 ### Added
 - Add support for PUT /reports/{id}/definition endpoint, Update Report Definition

--- a/mock-api-test-sdk-net80/DefaultHttpClientRetryTests.cs
+++ b/mock-api-test-sdk-net80/DefaultHttpClientRetryTests.cs
@@ -29,8 +29,8 @@ namespace mock_api_test_sdk_net80
             }
 
             // Override RetrySleep to optionally skip the actual sleep for fast tests
-            public override bool RetrySleep(int previousAttempts, long totalElapsedTime,
-                HttpStatusCode statusCode, Error error)
+            public override async Task<bool> RetrySleep(int previousAttempts, long totalElapsedTime,
+                HttpStatusCode statusCode, Error error, CancellationToken cancellationToken = default)
             {
                 long backoff = CalcBackoff(previousAttempts, totalElapsedTime, error);
                 if (backoff < 0)
@@ -41,7 +41,7 @@ namespace mock_api_test_sdk_net80
 
                 // Skip sleep in tests for fast execution
                 if (!SkipSleep)
-                    Thread.Sleep(TimeSpan.FromMilliseconds(backoff));
+                    await Task.Delay(TimeSpan.FromMilliseconds(backoff), cancellationToken).ConfigureAwait(false);
 
                 return true;
             }

--- a/mock-api-test-sdk-net80/HelperFunctions.cs
+++ b/mock-api-test-sdk-net80/HelperFunctions.cs
@@ -58,5 +58,37 @@ namespace mock_api_test_sdk_net80
                 Assert.Fail("Expected exception of type: {0}, actual type: {1}", (typeof(TException).Name), ex.GetType().Name);
             }
         }
+
+        ///<summary>
+        /// Awaits the asynchronous action and asserts that it throws an exception with the expected type and message.
+        /// Use this instead of the Action overload for async calls so the exception is observed on the awaited task
+        /// rather than escaping on an async-void continuation.
+        ///</summary>
+        ///<typeparam name="TException"></typeparam>
+        ///<param name="action"></param>
+        ///<param name="expectedMessage"></param>
+        public static async Task AssertRaisesExceptionAsync<TException>(Func<Task> action, string expectedMessage)
+            where TException : Exception
+        {
+            try
+            {
+                await action();
+                Assert.Fail("Call suceeded. Expected exception of type: {0} with message: {1}", (typeof(TException).Name), expectedMessage);
+            }
+            catch (TException ex)
+            {
+                Assert.AreEqual(expectedMessage, ex.Message, "Expected message: {0}", expectedMessage);
+            }
+            catch (AssertFailedException ex)
+            {
+#pragma warning disable CA2200 // Rethrow to preserve stack details
+                throw ex;
+#pragma warning restore CA2200 // Rethrow to preserve stack details
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected exception of type: {0}, actual type: {1}", (typeof(TException).Name), ex.GetType().Name);
+            }
+        }
     }
 }

--- a/mock-api-test-sdk-net80/SheetAsyncTests.cs
+++ b/mock-api-test-sdk-net80/SheetAsyncTests.cs
@@ -8,9 +8,9 @@ namespace mock_api_test_sdk_net80
     public class SheetTestsAsync
     {
         [TestMethod]
-        public async void ListSheetsAsync_NoParams()
+        public async Task ListSheetsAsync_NoParams()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("List Sheets Async - No Params");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("List Sheets - No Params");
 
             PaginatedResult<Sheet> sheets = await smartsheet.SheetResources.ListSheetsAsync(null, null);
 
@@ -18,9 +18,9 @@ namespace mock_api_test_sdk_net80
         }
 
         [TestMethod]
-        public async void ListSheetsAsync_IncludeOwnerInfo()
+        public async Task ListSheetsAsync_IncludeOwnerInfo()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("List Sheets Async - Include Owner Info");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("List Sheets - Include Owner Info");
 
             PaginatedResult<Sheet> sheets = await smartsheet.SheetResources.ListSheetsAsync(new List<SheetInclusion> { SheetInclusion.OWNER_INFO });
 
@@ -28,9 +28,9 @@ namespace mock_api_test_sdk_net80
         }
 
         [TestMethod]
-        public async void CreateSheetFromTemplateAsync_NoColumns()
+        public async Task CreateSheetFromTemplateAsync_NoColumns()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Create Sheet From Template Async - Invalid - No Columns");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Create Sheet - Invalid - No Columns");
 
             Sheet sheetA = new Sheet
             {
@@ -38,8 +38,8 @@ namespace mock_api_test_sdk_net80
                 Columns = new List<Column>()
             };
 
-            HelperFunctions.AssertRaisesException<SmartsheetException>(async () =>
-                await smartsheet.SheetResources.CreateSheetFromTemplateAsync(sheetA),
+            await HelperFunctions.AssertRaisesExceptionAsync<SmartsheetException>(
+                () => smartsheet.SheetResources.CreateSheetFromTemplateAsync(sheetA),
                 "The new sheet requires either a fromId or columns.");
         }
     }

--- a/mock-api-test-sdk-net80/SheetAsyncTests.cs
+++ b/mock-api-test-sdk-net80/SheetAsyncTests.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Smartsheet.Api;
+using Smartsheet.Api.Models;
+
+namespace mock_api_test_sdk_net80
+{
+    [TestClass]
+    public class SheetTestsAsync
+    {
+        [TestMethod]
+        public async void ListSheetsAsync_NoParams()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("List Sheets Async - No Params");
+
+            PaginatedResult<Sheet> sheets = await smartsheet.SheetResources.ListSheetsAsync(null, null);
+
+            Assert.IsNotNull(sheets.Data.Where(s => s.Name.Equals("Copy of Sample Sheet")).FirstOrDefault());
+        }
+
+        [TestMethod]
+        public async void ListSheetsAsync_IncludeOwnerInfo()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("List Sheets Async - Include Owner Info");
+
+            PaginatedResult<Sheet> sheets = await smartsheet.SheetResources.ListSheetsAsync(new List<SheetInclusion> { SheetInclusion.OWNER_INFO });
+
+            Assert.IsNotNull(sheets.Data.Where(s => s.Owner.Equals("john.doe@smartsheet.com")).FirstOrDefault());
+        }
+
+        [TestMethod]
+        public async void CreateSheetFromTemplateAsync_NoColumns()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Create Sheet From Template Async - Invalid - No Columns");
+
+            Sheet sheetA = new Sheet
+            {
+                Name = "New Sheet",
+                Columns = new List<Column>()
+            };
+
+            HelperFunctions.AssertRaisesException<SmartsheetException>(async () =>
+                await smartsheet.SheetResources.CreateSheetFromTemplateAsync(sheetA),
+                "The new sheet requires either a fromId or columns.");
+        }
+    }
+}

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
@@ -186,9 +186,7 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
         protected internal virtual T GetResource<T>(string path, Type objectClass)
         {
-            var task = GetResourceAsync<T>(path, objectClass);
-            task.Wait();
-            return task.Result;
+            return GetResourceAsync<T>(path, objectClass).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -287,9 +285,7 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
         protected internal virtual S CreateResource<S, T>(string path, T @object)
         {
-            var task = CreateResourceAsync<S, T>(path, @object);
-            task.Wait();
-            return task.Result;
+            return this.CreateResourceAsync<S, T>(path, @object).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -362,9 +358,7 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
         protected internal virtual T CreateResource<T>(string path, Type objectClass, T @object)
         {
-            var task = CreateResourceAsync<T>(path, objectClass, @object);
-            task.Wait();
-            return task.Result;
+            return this.CreateResourceAsync<T>(path, objectClass, @object).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -432,6 +426,22 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="InvalidOperationException"> if any argument is null, or path is an empty string </exception>
         protected internal virtual T CreateResourceWithAttachment<T>(string path, T @object, string objectType, string file, string fileType)
         {
+            return this.CreateResourceWithAttachmentAsync(path, @object, objectType, file, fileType).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Create a resource with an attachment.
+        /// </summary>
+        /// <param name="path"> the relative path of the resource collections </param>
+        /// <param name="object">the object to create </param>
+        /// <param name="file"> the file path </param>
+        /// <param name="fileType"> the file type, can be null </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <param name="objectType"> the object type to return as </param>
+        /// <returns> the created resource </returns>
+        /// <exception cref="InvalidOperationException"> if any argument is null, or path is an empty string </exception>
+        protected async internal virtual Task<T> CreateResourceWithAttachmentAsync<T>(string path, T @object, string objectType, string file, string fileType, CancellationToken cancellationToken = default)
+        {
             Utils.ThrowIfNull(path, @object);
             Utils.ThrowIfEmpty(path);
 
@@ -446,7 +456,7 @@ namespace Smartsheet.Api.Internal
             }
 
             request.Entity = serializeToEntity<T>(@object);
-            HttpResponse response = this.smartsheet.HttpClient.Request(request, objectType, file, fileType);
+            HttpResponse response = await this.smartsheet.HttpClient.RequestAsync(request, objectType, file, fileType, cancellationToken).ConfigureAwait(false);
 
             Object obj = null;
             switch (response.StatusCode)
@@ -484,9 +494,7 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
         protected internal virtual T UpdateResource<T>(string path, Type objectClass, T @object)
         {
-            var task = UpdateResourceAsync<T>(path, objectClass, @object);
-            task.Wait();
-            return task.Result;
+            return this.UpdateResourceAsync<T>(path, objectClass, @object).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -609,6 +617,26 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if an error occurred during the operation </exception>
         protected internal virtual PaginatedResult<T> ListResourcesWithWrapper<T>(string path)
         {
+            return this.ListResourcesWithWrapperAsync<T>(path).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Asynchronously list resources using SmartsheetClient REST API.
+        /// 
+        /// Exceptions:
+        ///   IllegalArgumentException : if any argument is null, or path is an empty string
+        ///   InvalidRequestException : if there is any problem with the REST API request
+        ///   AuthorizationException : if there is any problem with the REST API authorization (access token)
+        ///   ServiceUnavailableException : if the REST API service is not available (possibly due to rate limiting)
+        ///   SmartsheetRestException : if any other REST API related error occurred during the operation
+        ///   SmartsheetException : if any other error occurred during the operation
+        /// </summary>
+        /// <param name="path"> the relative path of the resource collections </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the resources </returns>
+        /// <exception cref="SmartsheetException"> if an error occurred during the operation </exception>
+        protected internal async virtual Task<PaginatedResult<T>> ListResourcesWithWrapperAsync<T>(string path, CancellationToken cancellationToken = default)
+        {
             Utils.ThrowIfNull(path);
             Utils.ThrowIfEmpty(path);
 
@@ -622,7 +650,7 @@ namespace Smartsheet.Api.Internal
                 throw new SmartsheetException(e);
             }
 
-            HttpResponse response = this.smartsheet.HttpClient.Request(request);
+            HttpResponse response = await this.smartsheet.HttpClient.RequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             PaginatedResult<T> obj = null;
             switch (response.StatusCode)
@@ -657,6 +685,26 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if an error occurred during the operation </exception>
         protected internal virtual TokenPaginatedResult<T> ListResourcesWithTokenWrapper<T>(string path)
         {
+            return this.ListResourcesWithTokenWrapperAsync<T>(path).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// List resources using SmartsheetClient REST API with token-based pagination.
+        /// 
+        /// Exceptions:
+        ///   IllegalArgumentException : if any argument is null, or path is an empty string
+        ///   InvalidRequestException : if there is any problem with the REST API request
+        ///   AuthorizationException : if there is any problem with the REST API authorization (access token)
+        ///   ServiceUnavailableException : if the REST API service is not available (possibly due to rate limiting)
+        ///   SmartsheetRestException : if any other REST API related error occurred during the operation
+        ///   SmartsheetException : if any other error occurred during the operation
+        /// </summary>
+        /// <param name="path"> the relative path of the resource collections </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the resources with token-based pagination </returns>
+        /// <exception cref="SmartsheetException"> if an error occurred during the operation </exception>
+        protected internal async virtual Task<TokenPaginatedResult<T>> ListResourcesWithTokenWrapperAsync<T>(string path, CancellationToken cancellationToken = default)
+        {
             Utils.ThrowIfNull(path);
             Utils.ThrowIfEmpty(path);
 
@@ -670,7 +718,7 @@ namespace Smartsheet.Api.Internal
                 throw new SmartsheetException(e);
             }
 
-            HttpResponse response = this.smartsheet.HttpClient.Request(request);
+            HttpResponse response = await this.smartsheet.HttpClient.RequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             TokenPaginatedResult<T> obj = null;
             switch (response.StatusCode)
@@ -705,6 +753,26 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if an error occurred during the operation </exception>
         protected internal virtual IList<T> ListResources<T>(string path, Type objectClass)
         {
+            return this.ListResourcesAsync<T>(path, objectClass).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// List resources using SmartsheetClient REST API.
+        /// 
+        /// Exceptions:
+        ///   IllegalArgumentException : if any argument is null, or path is an empty string
+        ///   InvalidRequestException : if there is any problem with the REST API request
+        ///   AuthorizationException : if there is any problem with the REST API authorization (access token)
+        ///   ServiceUnavailableException : if the REST API service is not available (possibly due to rate limiting)
+        ///   SmartsheetRestException : if any other REST API related error occurred during the operation
+        ///   SmartsheetException : if any other error occurred during the operation
+        /// </summary>
+        /// <param name="path"> the relative path of the resource collections </param>
+        /// <param name="objectClass"> the resource object class </param>
+        /// <returns> the resources </returns>
+        /// <exception cref="SmartsheetException"> if an error occurred during the operation </exception>
+        protected async internal virtual Task<IList<T>> ListResourcesAsync<T>(string path, Type objectClass, CancellationToken cancellationToken = default)
+        {
             Utils.ThrowIfNull(path, objectClass);
             Utils.ThrowIfEmpty(path);
 
@@ -718,7 +786,7 @@ namespace Smartsheet.Api.Internal
                 throw new SmartsheetException(e);
             }
 
-            HttpResponse response = this.smartsheet.HttpClient.Request(request);
+            HttpResponse response = await this.smartsheet.HttpClient.RequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             IList<T> obj = null;
             switch (response.StatusCode)
@@ -753,6 +821,26 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
         protected internal virtual T DeleteResource<T>(string path)
         {
+            return this.DeleteResourceAsync<T>(path).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Delete a resource from SmartsheetClient REST API.
+        /// 
+        /// Exceptions:
+        ///   IllegalArgumentException : if any argument is null, or path is an empty string
+        ///   InvalidRequestException : if there is any problem with the REST API request
+        ///   AuthorizationException : if there is any problem with the REST API authorization (access token)
+        ///   ResourceNotFoundException : if the resource cannot be found
+        ///   ServiceUnavailableException : if the REST API service is not available (possibly due to rate limiting)
+        ///   SmartsheetRestException : if any other REST API related error occurred during the operation
+        ///   SmartsheetException : if any other error occurred during the operation
+        /// </summary>
+        /// <param name="path"> the relative path of the resource </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
+        protected async internal virtual Task<T> DeleteResourceAsync<T>(string path, CancellationToken cancellationToken = default)
+        {
             Utils.ThrowIfNull(path);
             Utils.ThrowIfEmpty(path);
 
@@ -765,7 +853,7 @@ namespace Smartsheet.Api.Internal
             {
                 throw new SmartsheetException(e);
             }
-            HttpResponse response = this.smartsheet.HttpClient.Request(request);
+            HttpResponse response = await this.smartsheet.HttpClient.RequestAsync(request, cancellationToken).ConfigureAwait(false);
             Object obj = null;
             switch (response.StatusCode)
             {
@@ -799,6 +887,27 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
         protected internal virtual void DeleteResource<T>(string path, Type objectClass)
         {
+            this.DeleteResourceAsync<T>(path, objectClass).Wait();
+        }
+
+        /// <summary>
+        /// Asynchronously delete a resource from SmartsheetClient REST API.
+        /// 
+        /// Exceptions:
+        ///   IllegalArgumentException : if any argument is null, or path is an empty string
+        ///   InvalidRequestException : if there is any problem with the REST API request
+        ///   AuthorizationException : if there is any problem with the REST API authorization (access token)
+        ///   ResourceNotFoundException : if the resource cannot be found
+        ///   ServiceUnavailableException : if the REST API service is not available (possibly due to rate limiting)
+        ///   SmartsheetRestException : if any other REST API related error occurred during the operation
+        ///   SmartsheetException : if any other error occurred during the operation
+        /// </summary>
+        /// <param name="path"> the relative path of the resource </param>
+        /// <param name="objectClass"> the resource object class </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
+        protected internal async virtual Task DeleteResourceAsync<T>(string path, Type objectClass, CancellationToken cancellationToken = default)
+        {
             Utils.ThrowIfNull(path, objectClass);
             Utils.ThrowIfEmpty(path);
 
@@ -811,7 +920,7 @@ namespace Smartsheet.Api.Internal
             {
                 throw new SmartsheetException(e);
             }
-            HttpResponse response = this.smartsheet.HttpClient.Request(request);
+            HttpResponse response = await this.smartsheet.HttpClient.RequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             switch (response.StatusCode)
             {

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
@@ -395,7 +395,7 @@ namespace Smartsheet.Api.Internal
 
             request.Entity = serializeToEntity<T>(@object);
 
-            HttpResponse response = await this.smartsheet.HttpClient.RequestAsync(request).ConfigureAwait(false);
+            HttpResponse response = await this.smartsheet.HttpClient.RequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             Object obj = null;
             switch (response.StatusCode)

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
@@ -26,6 +26,8 @@ namespace Smartsheet.Api.Internal
     using System.IO;
     using System.Net;
     using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
     using HttpEntity = Api.Internal.Http.HttpEntity;
     using HttpMethod = Api.Internal.Http.HttpMethod;
     using HttpRequest = Api.Internal.Http.HttpRequest;
@@ -204,6 +206,85 @@ namespace Smartsheet.Api.Internal
             }
 
             HttpResponse response = this.smartsheet.HttpClient.Request(request);
+
+            Object obj = null;
+
+            switch (response.StatusCode)
+            {
+                case HttpStatusCode.OK:
+                    try
+                    {
+                        obj = this.smartsheet.JsonSerializer.deserialize<T>(response.Entity.GetContent());
+                    }
+                    catch (JsonSerializationException ex)
+                    {
+                        throw new SmartsheetException(ex);
+                    }
+                    catch (Newtonsoft.Json.JsonException ex)
+                    {
+                        throw new SmartsheetException(ex);
+                    }
+                    catch (IOException ex)
+                    {
+                        throw new SmartsheetException(ex);
+                    }
+                    break;
+                default:
+                    HandleError(response);
+                    break;
+            }
+
+            smartsheet.HttpClient.ReleaseConnection();
+
+            return (T)obj;
+        }
+
+        /// <summary>
+        /// Get a resource from SmartsheetClient REST API.
+        /// 
+        /// Parameters: - 
+        ///   path : the relative path of the resource
+        ///   objectClass : the resource object class
+        ///   cancellationToken : the cancellation token
+        /// 
+        /// Returns: the resource (note that if there is no such resource, this method will throw ResourceNotFoundException
+        /// rather than returning null).
+        /// 
+        /// Exceptions: -
+        ///   InvalidRequestException : if there is any problem with the REST API request
+        ///   AuthorizationException : if there is any problem with the REST API authorization (access token)
+        ///   ResourceNotFoundException : if the resource cannot be found
+        ///   ServiceUnavailableException : if the REST API service is not available (possibly due to rate limiting)
+        ///   SmartsheetRestException : if any other REST API related error occurred during the operation
+        ///   SmartsheetException : if any other error occurred during the operation
+        /// </summary>
+        /// <param name="path"> the relative path of the resource. </param>
+        /// <param name="objectClass"> the object class </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the resource </returns>
+        /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
+        protected internal virtual async Task<T> GetResource<T>(string path, Type objectClass, CancellationToken cancellationToken = default)
+        {
+            Utils.ThrowIfNull(path, objectClass);
+
+            if (path == null || path.Length == 0)
+            {
+                Api.Models.Error error = new Api.Models.Error();
+                error.Message = "An empty path was provided.";
+                throw new ResourceNotFoundException(error);
+            }
+
+            HttpRequest request = null;
+            try
+            {
+                request = CreateHttpRequest(new Uri(smartsheet.BaseURI, path), HttpMethod.GET);
+            }
+            catch (Exception e)
+            {
+                throw new SmartsheetException(e);
+            }
+
+            HttpResponse response = await this.smartsheet.HttpClient.RequestAsync(request, cancellationToken);
 
             Object obj = null;
 

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
@@ -512,6 +512,7 @@ namespace Smartsheet.Api.Internal
         /// <param name="path"> the relative path of the resource </param>
         /// <param name="objectClass"> the resource object class </param>
         /// <param name="object"> the object to create </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
         /// <returns> the updated resource </returns>
         /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
         protected internal virtual async Task<T> UpdateResourceAsync<T>(string path, Type objectClass, T @object, CancellationToken cancellationToken = default)
@@ -769,6 +770,7 @@ namespace Smartsheet.Api.Internal
         /// </summary>
         /// <param name="path"> the relative path of the resource collections </param>
         /// <param name="objectClass"> the resource object class </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
         /// <returns> the resources </returns>
         /// <exception cref="SmartsheetException"> if an error occurred during the operation </exception>
         protected async internal virtual Task<IList<T>> ListResourcesAsync<T>(string path, Type objectClass, CancellationToken cancellationToken = default)
@@ -887,7 +889,7 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
         protected internal virtual void DeleteResource<T>(string path, Type objectClass)
         {
-            this.DeleteResourceAsync<T>(path, objectClass).Wait();
+            this.DeleteResourceAsync<T>(path, objectClass).GetAwaiter().GetResult();
         }
 
         /// <summary>

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
@@ -186,61 +186,13 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
         protected internal virtual T GetResource<T>(string path, Type objectClass)
         {
-            Utils.ThrowIfNull(path, objectClass);
-
-            if (path == null || path.Length == 0)
-            {
-                Api.Models.Error error = new Api.Models.Error();
-                error.Message = "An empty path was provided.";
-                throw new ResourceNotFoundException(error);
-            }
-
-            HttpRequest request = null;
-            try
-            {
-                request = CreateHttpRequest(new Uri(smartsheet.BaseURI, path), HttpMethod.GET);
-            }
-            catch (Exception e)
-            {
-                throw new SmartsheetException(e);
-            }
-
-            HttpResponse response = this.smartsheet.HttpClient.Request(request);
-
-            Object obj = null;
-
-            switch (response.StatusCode)
-            {
-                case HttpStatusCode.OK:
-                    try
-                    {
-                        obj = this.smartsheet.JsonSerializer.deserialize<T>(response.Entity.GetContent());
-                    }
-                    catch (JsonSerializationException ex)
-                    {
-                        throw new SmartsheetException(ex);
-                    }
-                    catch (Newtonsoft.Json.JsonException ex)
-                    {
-                        throw new SmartsheetException(ex);
-                    }
-                    catch (IOException ex)
-                    {
-                        throw new SmartsheetException(ex);
-                    }
-                    break;
-                default:
-                    HandleError(response);
-                    break;
-            }
-
-            smartsheet.HttpClient.ReleaseConnection();
-
-            return (T)obj;
+            var task = GetResourceAsync<T>(path, objectClass);
+            task.Wait();
+            return task.Result;
         }
 
         /// <summary>
-        /// Get a resource from SmartsheetClient REST API.
+        /// Asynchronously get a resource from SmartsheetClient REST API.
         /// 
         /// Parameters: - 
         ///   path : the relative path of the resource
@@ -263,7 +215,7 @@ namespace Smartsheet.Api.Internal
         /// <param name="cancellationToken"> the cancellation token </param>
         /// <returns> the resource </returns>
         /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
-        protected internal virtual async Task<T> GetResource<T>(string path, Type objectClass, CancellationToken cancellationToken = default)
+        protected internal virtual async Task<T> GetResourceAsync<T>(string path, Type objectClass, CancellationToken cancellationToken = default)
         {
             Utils.ThrowIfNull(path, objectClass);
 

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
@@ -236,7 +236,7 @@ namespace Smartsheet.Api.Internal
                 throw new SmartsheetException(e);
             }
 
-            HttpResponse response = await this.smartsheet.HttpClient.RequestAsync(request, cancellationToken);
+            HttpResponse response = await this.smartsheet.HttpClient.RequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             Object obj = null;
 

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
@@ -287,6 +287,29 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
         protected internal virtual S CreateResource<S, T>(string path, T @object)
         {
+            var task = CreateResourceAsync<S, T>(path, @object);
+            task.Wait();
+            return task.Result;
+        }
+
+        /// <summary>
+        /// Create a resource using SmartsheetClient REST API.
+        /// 
+        /// Exceptions: 
+        ///   IllegalArgumentException : if any argument is null, or path is an empty string
+        ///   InvalidRequestException : if there is any problem with the REST API request
+        ///   AuthorizationException : if there is any problem with the REST API authorization (access token)
+        ///   ServiceUnavailableException : if the REST API service is not available (possibly due to rate limiting)
+        ///   SmartsheetRestException : if any other REST API related error occurred during the operation
+        ///   SmartsheetException : if any other error occurred during the operation
+        /// </summary>
+        /// <param name="path"> the relative path of the resource collections </param>
+        /// <param name="object"> the object to create </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the created resource </returns>
+        /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
+        protected internal virtual async Task<S> CreateResourceAsync<S, T>(string path, T @object, CancellationToken cancellationToken = default)
+        {
             Utils.ThrowIfNull(path, @object);
             Utils.ThrowIfEmpty(path);
 
@@ -302,7 +325,7 @@ namespace Smartsheet.Api.Internal
 
             request.Entity = serializeToEntity<T>(@object);
 
-            HttpResponse response = this.smartsheet.HttpClient.Request(request);
+            HttpResponse response = await this.smartsheet.HttpClient.RequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             Object obj = null;
             switch (response.StatusCode)
@@ -339,6 +362,30 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
         protected internal virtual T CreateResource<T>(string path, Type objectClass, T @object)
         {
+            var task = CreateResourceAsync<T>(path, objectClass, @object);
+            task.Wait();
+            return task.Result;
+        }
+
+        /// <summary>
+        /// Create a resource using SmartsheetClient REST API.
+        /// 
+        /// Exceptions: 
+        ///   IllegalArgumentException : if any argument is null, or path is an empty string
+        ///   InvalidRequestException : if there is any problem with the REST API request
+        ///   AuthorizationException : if there is any problem with the REST API authorization (access token)
+        ///   ServiceUnavailableException : if the REST API service is not available (possibly due to rate limiting)
+        ///   SmartsheetRestException : if any other REST API related error occurred during the operation
+        ///   SmartsheetException : if any other error occurred during the operation
+        /// </summary>
+        /// <param name="path"> the relative path of the resource collections </param>
+        /// <param name="objectClass"> the resource object class </param>
+        /// <param name="object"> the object to create </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the created resource </returns>
+        /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
+        protected internal async virtual Task<T> CreateResourceAsync<T>(string path, Type objectClass, T @object, CancellationToken cancellationToken = default)
+        {
             Utils.ThrowIfNull(path, @object);
             Utils.ThrowIfEmpty(path);
 
@@ -354,7 +401,7 @@ namespace Smartsheet.Api.Internal
 
             request.Entity = serializeToEntity<T>(@object);
 
-            HttpResponse response = this.smartsheet.HttpClient.Request(request);
+            HttpResponse response = await this.smartsheet.HttpClient.RequestAsync(request).ConfigureAwait(false);
 
             Object obj = null;
             switch (response.StatusCode)
@@ -437,6 +484,30 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
         protected internal virtual T UpdateResource<T>(string path, Type objectClass, T @object)
         {
+            var task = UpdateResourceAsync<T>(path, objectClass, @object);
+            task.Wait();
+            return task.Result;
+        }
+
+        /// <summary>
+        /// Asynchronously update a resource using SmartsheetClient REST API.
+        /// 
+        /// Exceptions:
+        ///   IllegalArgumentException : if any argument is null, or path is an empty string
+        ///   InvalidRequestException : if there is any problem with the REST API request
+        ///   AuthorizationException : if there is any problem with the REST API authorization (access token)
+        ///   ResourceNotFoundException : if the resource cannot be found
+        ///   ServiceUnavailableException : if the REST API service is not available (possibly due to rate limiting)
+        ///   SmartsheetRestException : if any other REST API related error occurred during the operation
+        ///   SmartsheetException : if any other error occurred during the operation
+        /// </summary>
+        /// <param name="path"> the relative path of the resource </param>
+        /// <param name="objectClass"> the resource object class </param>
+        /// <param name="object"> the object to create </param>
+        /// <returns> the updated resource </returns>
+        /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
+        protected internal virtual async Task<T> UpdateResourceAsync<T>(string path, Type objectClass, T @object, CancellationToken cancellationToken = default)
+        {
             Utils.ThrowIfNull(path, @object);
             Utils.ThrowIfEmpty(path);
 
@@ -452,7 +523,7 @@ namespace Smartsheet.Api.Internal
 
             request.Entity = serializeToEntity<T>(@object);
 
-            HttpResponse response = this.smartsheet.HttpClient.Request(request);
+            HttpResponse response = await this.smartsheet.HttpClient.RequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             Object obj = null;
             switch (response.StatusCode)

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Http/DefaultHttpClient.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Http/DefaultHttpClient.cs
@@ -146,7 +146,7 @@ namespace Smartsheet.Api.Internal.Http
         /// <param name="objectType">the object name, for example 'comment', or 'discussion'</param>
         /// <returns> the HTTP response </returns>
         /// <exception cref="HttpClientException"> the HTTP client exception </exception>
-        private async Task<HttpResponse> RequestAsync(HttpRequest smartsheetRequest, string objectType, string file, string fileType)
+        public async Task<HttpResponse> RequestAsync(HttpRequest smartsheetRequest, string objectType, string file, string fileType)
         {
             Util.ThrowIfNull(smartsheetRequest);
             if (smartsheetRequest.Uri == null)
@@ -244,9 +244,10 @@ namespace Smartsheet.Api.Internal.Http
         /// Make an HTTP request and return the response.
         /// </summary>
         /// <param name="smartsheetRequest"> the Smartsheet request </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
         /// <returns> the HTTP response </returns>
         /// <exception cref="HttpClientException"> the HTTP client exception </exception>
-        private async Task<HttpResponse> RequestAsync(HttpRequest smartsheetRequest)
+        public async Task<HttpResponse> RequestAsync(HttpRequest smartsheetRequest, CancellationToken cancellationToken = default)
         {
             Util.ThrowIfNull(smartsheetRequest);
             if (smartsheetRequest.Uri == null)
@@ -295,7 +296,7 @@ namespace Smartsheet.Api.Internal.Http
 
                 // Make the HTTP request
                 timer.Start();
-                Task<RestResponse> restResponseAsTask = this.httpClient.ExecuteAsync(restRequest);
+                Task<RestResponse> restResponseAsTask = this.httpClient.ExecuteAsync(restRequest, cancellationToken);
                 restResponseAsTask.Wait();
                 restResponse = restResponseAsTask.Result;
                 timer.Stop();

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Http/DefaultHttpClient.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Http/DefaultHttpClient.cs
@@ -135,10 +135,11 @@ namespace Smartsheet.Api.Internal.Http
         /// <param name="smartsheetRequest"> the Smartsheet request </param>
         /// <param name="file">the full file path</param>
         /// <param name="fileType">the file type, or also called the conent type of the file</param>
+        /// <param name="cancellationToken"> the cancellation token </param>
         /// <param name="objectType">the object name, for example 'comment', or 'discussion'</param>
         /// <returns> the HTTP response </returns>
         /// <exception cref="HttpClientException"> the HTTP client exception </exception>
-        public async Task<HttpResponse> RequestAsync(HttpRequest smartsheetRequest, string objectType, string file, string fileType)
+        public async Task<HttpResponse> RequestAsync(HttpRequest smartsheetRequest, string objectType, string file, string fileType, CancellationToken cancellationToken = default)
         {
             Util.ThrowIfNull(smartsheetRequest);
             if (smartsheetRequest.Uri == null)
@@ -174,7 +175,7 @@ namespace Smartsheet.Api.Internal.Http
 
             // Make the HTTP request
             timer.Start();
-            RestResponse restResponse = await this.httpClient.ExecuteAsync(restRequest);
+            RestResponse restResponse = await this.httpClient.ExecuteAsync(restRequest, cancellationToken).ConfigureAwait(false);
             timer.Stop();
 
             LogRequest(restRequest, restResponse, timer.ElapsedMilliseconds);
@@ -415,9 +416,7 @@ namespace Smartsheet.Api.Internal.Http
         /// <returns>true if this error code can be retried</returns>
         public virtual bool ShouldRetry(int previousAttempts, long totalElapsedTime, HttpResponse response)
         {
-            var task = ShouldRetryAsync(previousAttempts, totalElapsedTime, response);
-            task.Wait();
-            return task.Result;
+            return ShouldRetryAsync(previousAttempts, totalElapsedTime, response).GetAwaiter().GetResult();
         }
 
         /// <summary>

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Http/DefaultHttpClient.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Http/DefaultHttpClient.cs
@@ -118,16 +118,7 @@ namespace Smartsheet.Api.Internal.Http
         /// <returns></returns>
         /// <exception cref="SmartsheetException"></exception>
         public virtual HttpResponse Request(HttpRequest smartsheetRequest, string objectType, string file, string fileType) {
-            HttpResponse response = new HttpResponse();
-            // C# tasks will wrap any responses in an AggregateException we will unwrap and send the first inner exception instead.
-            try {
-                var task = this.RequestAsync(smartsheetRequest, objectType, file, fileType);
-                task.Wait();
-                response = task.Result;
-            } catch (AggregateException ex) {
-                throw new SmartsheetException(ex.InnerException.Message);
-            }
-            return response;
+            return this.RequestAsync(smartsheetRequest, objectType, file, fileType).GetAwaiter().GetResult();
         }
         /// <summary>
         /// Make a multipart HTTP request and return the response.
@@ -218,18 +209,7 @@ namespace Smartsheet.Api.Internal.Http
         /// <returns></returns>
         /// <exception cref="SmartsheetException"></exception>
         public virtual HttpResponse Request(HttpRequest smartsheetRequest) {
-            HttpResponse response = new HttpResponse();
-            // C# tasks will wrap any responses in an AggregateException we will unwrap and send the first inner exception instead.
-            // This helps with error mock api tests.
-            try {
-                var task = this.RequestAsync(smartsheetRequest);
-                task.Wait();
-                response = task.Result;
-            } catch (AggregateException ex) {
-                throw new SmartsheetException(ex.InnerException.Message);
-            }
-
-            return response;
+            return this.RequestAsync(smartsheetRequest).GetAwaiter().GetResult();
         }
         /// <summary>
         /// Make an HTTP request and return the response.

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Http/DefaultHttpClient.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Http/DefaultHttpClient.cs
@@ -286,7 +286,7 @@ namespace Smartsheet.Api.Internal.Http
 
                 // Make the HTTP request
                 timer.Start();
-                RestResponse restResponse = await this.httpClient.ExecuteAsync(restRequest, cancellationToken);
+                RestResponse restResponse = await this.httpClient.ExecuteAsync(restRequest, cancellationToken).ConfigureAwait(false);
                 timer.Stop();
 
                 LogRequest(restRequest, restResponse, timer.ElapsedMilliseconds);
@@ -318,7 +318,7 @@ namespace Smartsheet.Api.Internal.Http
                     break;
                 }
 
-                bool shouldRetry = await ShouldRetryAsync(++attempt, totalElapsed.ElapsedMilliseconds, smartsheetResponse, cancellationToken);
+                bool shouldRetry = await ShouldRetryAsync(++attempt, totalElapsed.ElapsedMilliseconds, smartsheetResponse, cancellationToken).ConfigureAwait(false);
                 if (!shouldRetry)
                 {
                     if (restResponse.ResponseStatus == ResponseStatus.Error)
@@ -437,7 +437,7 @@ namespace Smartsheet.Api.Internal.Http
                 case TooManyRequests: // HTTP 429 (not available in netstandard2.0)
                 case HttpStatusCode.BadGateway:
                 case HttpStatusCode.ServiceUnavailable:
-                    return await RetrySleep(previousAttempts, totalElapsedTime, response.StatusCode, null, cancellationToken);
+                    return await RetrySleep(previousAttempts, totalElapsedTime, response.StatusCode, null, cancellationToken).ConfigureAwait(false);
             }
 
             string contentType = response.Entity.ContentType;
@@ -472,7 +472,7 @@ namespace Smartsheet.Api.Internal.Http
                 case 4002:
                 case 4003:
                 case 4004:
-                    return await RetrySleep(previousAttempts, totalElapsedTime, response.StatusCode, error);
+                    return await RetrySleep(previousAttempts, totalElapsedTime, response.StatusCode, error, cancellationToken).ConfigureAwait(false);
                 default:
                     return false;
             }
@@ -494,7 +494,7 @@ namespace Smartsheet.Api.Internal.Http
                 return false;
 
             logger.Info(string.Format("HttpError StatusCode={0}: Retrying in {1} milliseconds", statusCode, backoff));
-            await Task.Delay(TimeSpan.FromMilliseconds(backoff), cancellationToken);
+            await Task.Delay(TimeSpan.FromMilliseconds(backoff), cancellationToken).ConfigureAwait(false);
             return true;
         }
 

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Http/DefaultHttpClient.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Http/DefaultHttpClient.cs
@@ -70,14 +70,6 @@ namespace Smartsheet.Api.Internal.Http
         protected long maxRetryTimeout = 15000;
 
         /// <summary>
-        /// The http request. </summary>
-        private RestRequest restRequest;
-
-        /// <summary>
-        /// The http response. </summary>
-        private RestResponse restResponse;
-
-        /// <summary>
         /// UserAgent. </summary>
         private String userAgent;
 
@@ -156,7 +148,7 @@ namespace Smartsheet.Api.Internal.Http
 
             HttpResponse smartsheetResponse = new HttpResponse();
 
-            restRequest = CreateRestRequest(smartsheetRequest);
+            RestRequest restRequest = CreateRestRequest(smartsheetRequest);
 
             // Set HTTP Headers
             if (smartsheetRequest.Headers != null)
@@ -182,9 +174,7 @@ namespace Smartsheet.Api.Internal.Http
 
             // Make the HTTP request
             timer.Start();
-            Task<RestResponse> restResponseAsTask = this.httpClient.ExecuteAsync(restRequest);
-            restResponseAsTask.Wait();
-            restResponse = restResponseAsTask.Result;
+            RestResponse restResponse = await this.httpClient.ExecuteAsync(restRequest);
             timer.Stop();
 
             LogRequest(restRequest, restResponse, timer.ElapsedMilliseconds);
@@ -231,9 +221,9 @@ namespace Smartsheet.Api.Internal.Http
             // C# tasks will wrap any responses in an AggregateException we will unwrap and send the first inner exception instead.
             // This helps with error mock api tests.
             try {
-            var task = this.RequestAsync(smartsheetRequest);
-            task.Wait();
-            response = task.Result;
+                var task = this.RequestAsync(smartsheetRequest);
+                task.Wait();
+                response = task.Result;
             } catch (AggregateException ex) {
                 throw new SmartsheetException(ex.InnerException.Message);
             }
@@ -265,7 +255,7 @@ namespace Smartsheet.Api.Internal.Http
             {
                 smartsheetResponse = new HttpResponse();
 
-                restRequest = CreateRestRequest(smartsheetRequest);
+                RestRequest restRequest = CreateRestRequest(smartsheetRequest);
 
                 // Set HTTP Headers
                 if (smartsheetRequest.Headers != null)
@@ -296,9 +286,7 @@ namespace Smartsheet.Api.Internal.Http
 
                 // Make the HTTP request
                 timer.Start();
-                Task<RestResponse> restResponseAsTask = this.httpClient.ExecuteAsync(restRequest, cancellationToken);
-                restResponseAsTask.Wait();
-                restResponse = restResponseAsTask.Result;
+                RestResponse restResponse = await this.httpClient.ExecuteAsync(restRequest, cancellationToken);
                 timer.Stop();
 
                 LogRequest(restRequest, restResponse, timer.ElapsedMilliseconds);
@@ -330,7 +318,8 @@ namespace Smartsheet.Api.Internal.Http
                     break;
                 }
 
-                if (!ShouldRetry(++attempt, totalElapsed.ElapsedMilliseconds, smartsheetResponse))
+                bool shouldRetry = await ShouldRetryAsync(++attempt, totalElapsed.ElapsedMilliseconds, smartsheetResponse, cancellationToken);
+                if (!shouldRetry)
                 {
                     if (restResponse.ResponseStatus == ResponseStatus.Error)
                     {
@@ -426,14 +415,29 @@ namespace Smartsheet.Api.Internal.Http
         /// <returns>true if this error code can be retried</returns>
         public virtual bool ShouldRetry(int previousAttempts, long totalElapsedTime, HttpResponse response)
         {
+            var task = ShouldRetryAsync(previousAttempts, totalElapsedTime, response);
+            task.Wait();
+            return task.Result;
+        }
+
+        /// <summary>
+        /// Called by DefaultHttpClient when an async request fails to determine if we can retry the request. Calls
+        /// calcBackoff to determine time in between retries.
+        /// </summary>
+        /// <param name="previousAttempts"></param>
+        /// <param name="totalElapsedTime"></param>
+        /// <param name="response"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>true if this error code can be retried</returns>
+        public async virtual Task<bool> ShouldRetryAsync(int previousAttempts, long totalElapsedTime, HttpResponse response, CancellationToken cancellationToken = default)
+        {
             // Retry only for specific status codes regardless of response content type.
             switch (response.StatusCode)
             {
-
                 case TooManyRequests: // HTTP 429 (not available in netstandard2.0)
                 case HttpStatusCode.BadGateway:
                 case HttpStatusCode.ServiceUnavailable:
-                    return RetrySleep(previousAttempts, totalElapsedTime, response.StatusCode, null);
+                    return await RetrySleep(previousAttempts, totalElapsedTime, response.StatusCode, null, cancellationToken);
             }
 
             string contentType = response.Entity.ContentType;
@@ -468,28 +472,29 @@ namespace Smartsheet.Api.Internal.Http
                 case 4002:
                 case 4003:
                 case 4004:
-                    return RetrySleep(previousAttempts, totalElapsedTime, response.StatusCode, error);
+                    return await RetrySleep(previousAttempts, totalElapsedTime, response.StatusCode, error);
                 default:
                     return false;
             }
         }
 
         /// <summary>
-        /// Calculate backoff, log retry attempt, and sleep before retrying.
+        /// Asynchronously calculate backoff, log retry attempt, and sleep before retrying.
         /// </summary>
         /// <param name="previousAttempts">Number of previous attempts</param>
         /// <param name="totalElapsedTime">Total elapsed time in milliseconds</param>
         /// <param name="statusCode">HTTP status code for logging</param>
         /// <param name="error">Error object (optional, can be null for status code-based retries)</param>
+        /// <param name="cancellationToken">Cancellation token (optional)</param>
         /// <returns>True if retry should proceed, false if max retry time exceeded</returns>
-        public virtual bool RetrySleep(int previousAttempts, long totalElapsedTime, HttpStatusCode statusCode, Api.Models.Error error)
+        public async virtual Task<bool> RetrySleep(int previousAttempts, long totalElapsedTime, HttpStatusCode statusCode, Api.Models.Error error, CancellationToken cancellationToken = default)
         {
             long backoff = CalcBackoff(previousAttempts, totalElapsedTime, error);
             if (backoff < 0)
                 return false;
 
             logger.Info(string.Format("HttpError StatusCode={0}: Retrying in {1} milliseconds", statusCode, backoff));
-            Thread.Sleep(TimeSpan.FromMilliseconds(backoff));
+            await Task.Delay(TimeSpan.FromMilliseconds(backoff), cancellationToken);
             return true;
         }
 

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Http/HttpClient.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Http/HttpClient.cs
@@ -70,6 +70,18 @@ namespace Smartsheet.Api.Internal.Http
         Task<HttpResponse> RequestAsync(HttpRequest request, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Make an asynchronous multipart HTTP request and return the response.
+        /// </summary>
+        /// <param name="request"> the Smartsheet request </param>
+        /// <param name="file">the full file path</param>
+        /// <param name="fileType">the file type, or also called the conent type of the file</param>
+        /// <param name="cancellationToken"> cancellation token </param>
+        /// <param name="objectType">the object name, for example 'comment', or 'discussion'</param>
+        /// <returns> the HTTP response </returns>
+        /// <exception cref="HttpClientException"> the HTTP client exception </exception>
+        Task<HttpResponse> RequestAsync(HttpRequest request, string objectType, string file, string fileType, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Release connection.
         /// </summary>
         void ReleaseConnection();

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Http/HttpClient.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Http/HttpClient.cs
@@ -54,6 +54,22 @@ namespace Smartsheet.Api.Internal.Http
         HttpResponse Request(HttpRequest request);
 
         /// <summary>
+        /// Make an asynchronous HTTP request and return a Task that contains the response.
+        /// 
+        /// Parameters: - request : the HTTP request
+        /// 
+        /// Returns: a Task with the HTTP response
+        /// 
+        /// Exceptions: - IllegalArgumentException : if any argument is null - HttpClientException : if there is any other
+        /// error occurred during the operation
+        /// </summary>
+        /// <param name="request"> the request </param>
+        /// <param name="cancellationToken"> cancellation token </param>
+        /// <returns> the http response </returns>
+        /// <exception cref="HttpClientException"> the http client exception </exception>
+        Task<HttpResponse> RequestAsync(HttpRequest request, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Release connection.
         /// </summary>
         void ReleaseConnection();

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/SheetResourcesImpl.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/SheetResourcesImpl.cs
@@ -34,6 +34,8 @@ namespace Smartsheet.Api.Internal
     using Smartsheet.Api.Internal.Util;
     using System.Text;
     using Smartsheet.Api.Internal.Http;
+    using System.Threading.Tasks;
+    using System.Threading;
 
     /// <summary>
     /// This is the implementation of the SheetResources.
@@ -188,30 +190,7 @@ namespace Smartsheet.Api.Internal
             return this.ListResourcesWithWrapper<Sheet>(path.ToString());
         }
 
-        /// <summary>
-        /// <para>Gets a sheet.</para>
-        /// 
-        /// <para>Mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}</para>
-        /// </summary>
-        /// <param name="sheetId"> the Id of the sheet </param>
-        /// <param name="includes"> used to specify the optional objects to include. </param>
-        /// <param name="excludes"> used to specify the optional objects to include. </param>
-        /// <param name="rowIds"> used to specify the optional objects to include. </param>
-        /// <param name="rowNumbers"> used to specify the optional objects to include. </param>
-        /// <param name="columnIds"> used to specify the optional objects to include. </param>
-        /// <param name="pageSize"> used to specify the optional objects to include. </param>
-        /// <param name="page"> used to specify the optional objects to include. </param>
-        /// <param name="ifVersionAfter"> only fetch sheet if more recent version available </param>
-        /// <param name="level"> compatibility level </param>
-        /// <returns> the sheet resource (note that if there is no such resource, this method will throw 
-        /// ResourceNotFoundException rather than returning null). </returns>
-        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
-        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
-        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
-        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
-        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
-        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
-        public virtual Sheet GetSheet(long sheetId, IEnumerable<SheetLevelInclusion>? includes, IEnumerable<SheetLevelExclusion>? excludes,
+        private IDictionary<string, string> CreateSheetParameters(IEnumerable<SheetLevelInclusion>? includes, IEnumerable<SheetLevelExclusion>? excludes,
             IEnumerable<long>? rowIds, IEnumerable<int>? rowNumbers, IEnumerable<long>? columnIds, long? pageSize, long? page, DateTime? rowsModifiedSince, long? ifVersionAfter, int? level)
         {
             IDictionary<string, string> parameters = new Dictionary<string, string>();
@@ -255,7 +234,69 @@ namespace Smartsheet.Api.Internal
                 parameters.Add("level", level.ToString());
             }
 
+            return parameters;
+        }
+
+        /// <summary>
+        /// <para>Gets a sheet.</para>
+        /// 
+        /// <para>Mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}</para>
+        /// </summary>
+        /// <param name="sheetId"> the Id of the sheet </param>
+        /// <param name="includes"> used to specify the optional objects to include. </param>
+        /// <param name="excludes"> used to specify the optional objects to include. </param>
+        /// <param name="rowIds"> used to specify the optional objects to include. </param>
+        /// <param name="rowNumbers"> used to specify the optional objects to include. </param>
+        /// <param name="columnIds"> used to specify the optional objects to include. </param>
+        /// <param name="pageSize"> used to specify the optional objects to include. </param>
+        /// <param name="page"> used to specify the optional objects to include. </param>
+        /// <param name="ifVersionAfter"> only fetch sheet if more recent version available </param>
+        /// <param name="level"> compatibility level </param>
+        /// <returns> the sheet resource (note that if there is no such resource, this method will throw 
+        /// ResourceNotFoundException rather than returning null). </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public virtual Sheet GetSheet(long sheetId, IEnumerable<SheetLevelInclusion>? includes, IEnumerable<SheetLevelExclusion>? excludes,
+            IEnumerable<long>? rowIds, IEnumerable<int>? rowNumbers, IEnumerable<long>? columnIds, long? pageSize, long? page, DateTime? rowsModifiedSince, long? ifVersionAfter, int? level)
+        {
+            IDictionary<string, string> parameters = CreateSheetParameters(includes, excludes, rowIds, rowNumbers, columnIds, pageSize, page, rowsModifiedSince, ifVersionAfter, level);
             return this.GetResource<Sheet>("sheets/" + sheetId + QueryUtil.GenerateUrl(null, parameters), typeof(Sheet));
+        }
+
+        /// <summary>
+        /// <para>Asychronously gets a sheet.</para>
+        /// 
+        /// <para>Mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}</para>
+        /// </summary>
+        /// <param name="sheetId"> the Id of the sheet </param>
+        /// <param name="includes"> used to specify the optional objects to include. </param>
+        /// <param name="excludes"> used to specify the optional objects to include. </param>
+        /// <param name="rowIds"> used to specify the optional objects to include. </param>
+        /// <param name="rowNumbers"> used to specify the optional objects to include. </param>
+        /// <param name="columnIds"> used to specify the optional objects to include. </param>
+        /// <param name="pageSize"> used to specify the optional objects to include. </param>
+        /// <param name="page"> used to specify the optional objects to include. </param>
+        /// <param name="rowsModifiedSince"></param>
+        /// <param name="ifVersionAfter"> only fetch sheet if more recent version available </param>
+        /// <param name="level"> compatibility level </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the sheet resource (note that if there is no such resource, this method will throw 
+        /// ResourceNotFoundException rather than returning null). </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public virtual Task<Sheet> GetSheetAsync(long sheetId, IEnumerable<SheetLevelInclusion>? includes, IEnumerable<SheetLevelExclusion>? excludes,
+            IEnumerable<long>? rowIds, IEnumerable<int>? rowNumbers, IEnumerable<long>? columnIds, long? pageSize, long? page, DateTime? rowsModifiedSince, long? ifVersionAfter, int? level, CancellationToken cancellationToken = default)
+        {
+            IDictionary<string, string> parameters = CreateSheetParameters(includes, excludes, rowIds, rowNumbers, columnIds, pageSize, page, rowsModifiedSince, ifVersionAfter, level);
+            return this.GetResource<Sheet>("sheets/" + sheetId + QueryUtil.GenerateUrl(null, parameters), typeof(Sheet), cancellationToken);
         }
 
         /// <summary>

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/SheetResourcesImpl.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/SheetResourcesImpl.cs
@@ -152,6 +152,23 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual PaginatedResult<Sheet> ListSheets(IEnumerable<SheetInclusion>? includes, PaginationParameters? paging, DateTime? modifiedSince)
         {
+            return this.ListSheetsAsync(includes, paging, modifiedSince).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Gets the list of all sheets that the user has access to, in alphabetical order, by name.</para>
+        /// 
+        /// <para>Mirrors to the following Smartsheet REST API method: GET /Sheets</para>
+        /// </summary>
+        /// <returns> A list of all sheets (note that an empty list will be returned if there are none). </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task<PaginatedResult<Sheet>> ListSheetsAsync(IEnumerable<SheetInclusion>? includes, PaginationParameters? paging, DateTime? modifiedSince, CancellationToken cancellationToken = default)
+        {
             IDictionary<string, string> parameters = new Dictionary<string, string>();
             if (paging != null)
             {
@@ -166,7 +183,8 @@ namespace Smartsheet.Api.Internal
                 parameters.Add("modifiedSince", ((DateTime)modifiedSince).ToUniversalTime().ToString("o"));
             }
 
-            return this.ListResourcesWithWrapper<Sheet>("sheets" + QueryUtil.GenerateUrl(null, parameters));
+            PaginatedResult<Sheet> paginatedSheets = await this.ListResourcesWithWrapperAsync<Sheet>("sheets" + QueryUtil.GenerateUrl(null, parameters)).ConfigureAwait(false);
+            return paginatedSheets;
         }
 
         /// <summary>
@@ -182,12 +200,29 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual PaginatedResult<Sheet> ListOrganizationSheets(PaginationParameters? paging)
         {
+            return this.ListOrganizationSheetsAsync(paging).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Lists all sheets in the organization.</para>
+        /// <para>Mirrors to the following Smartsheet REST API method: GET /users/sheets</para>
+        /// </summary>
+        /// <returns> the list of all sheets (note that an empty list will be returned if there are none) </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task<PaginatedResult<Sheet>> ListOrganizationSheetsAsync(PaginationParameters? paging, CancellationToken cancellationToken = default)
+        {
             StringBuilder path = new StringBuilder("users/sheets");
             if (paging != null)
             {
                 path.Append(paging.ToQueryString());
             }
-            return this.ListResourcesWithWrapper<Sheet>(path.ToString());
+            PaginatedResult<Sheet> paginatedSheets = await this.ListResourcesWithWrapperAsync<Sheet>(path.ToString()).ConfigureAwait(false);
+            return paginatedSheets;
         }
 
         /// <summary>
@@ -217,9 +252,7 @@ namespace Smartsheet.Api.Internal
         public virtual Sheet GetSheet(long sheetId, IEnumerable<SheetLevelInclusion>? includes, IEnumerable<SheetLevelExclusion>? excludes,
             IEnumerable<long>? rowIds, IEnumerable<int>? rowNumbers, IEnumerable<long>? columnIds, long? pageSize, long? page, DateTime? rowsModifiedSince, long? ifVersionAfter, int? level)
         {
-            var task = this.GetSheetAsync(sheetId, includes, excludes, rowIds, rowNumbers, columnIds, pageSize, page, rowsModifiedSince, ifVersionAfter, level);
-            task.Wait();
-            return task.Result;
+            return this.GetSheetAsync(sheetId, includes, excludes, rowIds, rowNumbers, columnIds, pageSize, page, rowsModifiedSince, ifVersionAfter, level).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -389,12 +422,33 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual Sheet CreateSheetFromTemplate(Sheet sheet, IEnumerable<TemplateInclusion>? includes)
         {
+            return this.CreateSheetFromTemplateAsync(sheet, includes).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Creates a sheet (from existing sheet or template) in default "Sheets" collection.</para>
+        /// 
+        /// <para>Mirrors to the following Smartsheet REST API method: POST /Sheets</para>
+        /// </summary>
+        /// <param name="sheet"> the sheet to create </param>
+        /// <param name="includes"> used to specify the optional objects to include. </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the created sheet </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task<Sheet> CreateSheetFromTemplateAsync(Sheet sheet, IEnumerable<TemplateInclusion>? includes, CancellationToken cancellationToken = default)
+        {
             StringBuilder path = new StringBuilder("sheets");
             if (includes != null)
             {
                 path.Append("?include=" + QueryUtil.GenerateCommaSeparatedList(includes));
             }
-            return this.CreateResource(path.ToString(), typeof(Sheet), sheet);
+            Sheet createdSheet = await this.CreateResourceAsync(path.ToString(), typeof(Sheet), sheet, cancellationToken).ConfigureAwait(false);
+            return createdSheet;
         }
 
         /// <summary>
@@ -411,7 +465,25 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual void DeleteSheet(long sheetId)
         {
-            this.DeleteResource<Sheet>("sheets/" + sheetId, typeof(Sheet));
+            this.DeleteSheetAsync(sheetId).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Asynchronously deletes a sheet.</para>
+        /// 
+        /// <para>Mirrors to the following Smartsheet REST API method: DELETE /sheets/{sheetId}</para>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task DeleteSheetAsync(long sheetId, CancellationToken cancellationToken = default)
+        {
+            await this.DeleteResourceAsync<Sheet>("sheets/" + sheetId, typeof(Sheet), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -433,9 +505,7 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual Sheet UpdateSheet(Sheet sheet)
         {
-            var task = UpdateSheetAsync(sheet);
-            task.Wait();
-            return task.Result;
+            return this.UpdateSheetAsync(sheet).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -478,13 +548,11 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual int? GetSheetVersion(long sheetId)
         {
-            var task = GetSheetVersionAsync(sheetId);
-            task.Wait();
-            return task.Result;
+            return this.GetSheetVersionAsync(sheetId).GetAwaiter().GetResult();
         }
 
         /// <summary>
-        /// <para>Gets the sheet version asynchronously without loading the entire sheet.</para>
+        /// <para>Asynchronously gets the sheet version without loading the entire sheet.</para>
         /// 
         /// <para>Mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/version</para>
         /// </summary>
@@ -519,7 +587,7 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual void SendSheet(long sheetId, SheetEmail email)
         {
-            this.SendSheetAsync(sheetId, email).Wait();
+            this.SendSheetAsync(sheetId, email).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -556,7 +624,27 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual UpdateRequest SendUpdateRequest(long sheetId, MultiRowEmail email)
         {
-            return this.CreateResource<RequestResult<UpdateRequest>, MultiRowEmail>("sheets/" + sheetId + "/updaterequests", email).Result;
+            return this.SendUpdateRequestAsync(sheetId, email).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Asynchronously creates an update request for the specified rows within the sheet. An email notification
+        /// (containing a link to the update request) will be asynchronously sent to the specified recipients.</para>
+        /// <para>Mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/updaterequests</para>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id </param>
+        /// <param name="email"> the email </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task<UpdateRequest> SendUpdateRequestAsync(long sheetId, MultiRowEmail email, CancellationToken cancellationToken = default)
+        {
+            RequestResult<UpdateRequest> requestResult = await this.CreateResourceAsync<RequestResult<UpdateRequest>, MultiRowEmail>("sheets/" + sheetId + "/updaterequests", email, cancellationToken).ConfigureAwait(false);
+            return requestResult.Result;
         }
 
         /// <summary>
@@ -577,6 +665,28 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual Sheet CopySheet(long sheetId, ContainerDestination destination, IEnumerable<SheetCopyInclusion>? include, IEnumerable<SheetCopyExclusion>? exclude)
         {
+            return this.CopySheetAsync(sheetId, destination, include, exclude).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Asynchronously creates a copy of the specified sheet.</para>
+        /// <para>Mirrors to the following Smartsheet REST API method:<br />
+        /// POST /sheets/{sheetId}/copy</para>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id </param>
+        /// <param name="destination"> the destination to copy to </param>
+        /// <param name="include"> the elements to copy. Note: Cell history will not be copied, regardless of which include parameter values are specified.</param>
+        /// <param name="exclude"> optional elements to exclude </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the created folder </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task<Sheet> CopySheetAsync(long sheetId, ContainerDestination destination, IEnumerable<SheetCopyInclusion>? include, IEnumerable<SheetCopyExclusion>? exclude, CancellationToken cancellationToken = default)
+        {
             IDictionary<string, string> parameters = new Dictionary<string, string>();
             if (include != null)
             {
@@ -586,7 +696,8 @@ namespace Smartsheet.Api.Internal
             {
                 parameters.Add("exclude", QueryUtil.GenerateCommaSeparatedList(exclude));
             }
-            return this.CreateResource<RequestResult<Sheet>, ContainerDestination>(QueryUtil.GenerateUrl("sheets/" + sheetId + "/copy", parameters), destination).Result;
+            RequestResult<Sheet> requestResult = await this.CreateResourceAsync<RequestResult<Sheet>, ContainerDestination>(QueryUtil.GenerateUrl("sheets/" + sheetId + "/copy", parameters), destination, cancellationToken).ConfigureAwait(false);
+            return requestResult.Result;
         }
 
         /// <summary>
@@ -605,7 +716,28 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual Sheet MoveSheet(long sheetId, ContainerDestination destination)
         {
-            return this.CreateResource<RequestResult<Sheet>, ContainerDestination>("sheets/" + sheetId + "/move", destination).Result;
+            return this.MoveSheetAsync(sheetId, destination).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Asynchronously moves the specified sheet to a new location.</para>
+        /// <para>Mirrors to the following Smartsheet REST API method:<br />
+        /// POST /sheets/{sheetId}/move</para>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id </param>
+        /// <param name="destination"> the destination to copy to </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the moved sheet </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task<Sheet> MoveSheetAsync(long sheetId, ContainerDestination destination, CancellationToken cancellationToken = default)
+        {
+            RequestResult<Sheet> requestResult = await this.CreateResourceAsync<RequestResult<Sheet>, ContainerDestination>("sheets/" + sheetId + "/move", destination, cancellationToken).ConfigureAwait(false);
+            return requestResult.Result;
         }
 
         /// <summary>
@@ -622,9 +754,7 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual SheetPublish GetPublishStatus(long sheetId)
         {
-            var task = GetPublishStatusAsync(sheetId);
-            task.Wait();
-            return task.Result;
+            return this.GetPublishStatusAsync(sheetId).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -663,7 +793,29 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual SheetPublish UpdatePublishStatus(long id, SheetPublish publish)
         {
-            return this.UpdateResource("sheets/" + id + "/publish", typeof(SheetPublish), publish);
+            return this.UpdatePublishStatusAsync(id, publish).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Asynchronously sets the publish status of a sheet and returns the new status, including the URLs of any enabled publishings.</para>
+        /// 
+        /// <para>Mirrors to the following Smartsheet REST API method: PUT /sheets/{sheetId}/publish</para>
+        /// </summary>
+        /// <param name="id"> the sheet Id </param>
+        /// <param name="publish"> the SheetPublish object limited. </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the updated SheetPublish object (note that if there is no such resource, this method will throw a 
+        /// ResourceNotFoundException rather than returning null). </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task<SheetPublish> UpdatePublishStatusAsync(long id, SheetPublish publish, CancellationToken cancellationToken = default)
+        {
+            SheetPublish sheetPublish = await this.UpdateResourceAsync("sheets/" + id + "/publish", typeof(SheetPublish), publish, cancellationToken).ConfigureAwait(false);
+            return sheetPublish;
         }
 
         /// <summary>
@@ -683,6 +835,26 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual Sheet SortSheet(long id, SortSpecifier sortSpecifier, int? level)
         {
+            return this.SortSheetAsync(id, sortSpecifier, level).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Asynchronously sorts a sheet according to the sort criteria.</para>
+        /// 
+        /// <para>Mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/sort</para>
+        /// </summary>
+        /// <param name="id"> the sheet Id </param>
+        /// <param name="sortSpecifier"> the sort criteria </param>
+        /// <param name="level"> compatibility level </param>
+        /// <returns> the sheet (note that if there is no such resource, this method will throw a ResourceNotFoundException rather than returning null). </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task<Sheet> SortSheetAsync(long id, SortSpecifier sortSpecifier, int? level, CancellationToken cancellationToken = default)
+        {
             HttpRequest request = null;
             try
             {
@@ -701,7 +873,7 @@ namespace Smartsheet.Api.Internal
 
             request.Entity = serializeToEntity<SortSpecifier>(sortSpecifier);
 
-            HttpResponse response = this.Smartsheet.HttpClient.Request(request);
+            HttpResponse response = await this.Smartsheet.HttpClient.RequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             Object obj = null;
             switch (response.StatusCode)

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/SheetResourcesImpl.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/SheetResourcesImpl.cs
@@ -247,7 +247,7 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
-        public virtual Task<Sheet> GetSheetAsync(long sheetId, IEnumerable<SheetLevelInclusion>? includes, IEnumerable<SheetLevelExclusion>? excludes,
+        public virtual async Task<Sheet> GetSheetAsync(long sheetId, IEnumerable<SheetLevelInclusion>? includes, IEnumerable<SheetLevelExclusion>? excludes,
             IEnumerable<long>? rowIds, IEnumerable<int>? rowNumbers, IEnumerable<long>? columnIds, long? pageSize, long? page, DateTime? rowsModifiedSince, long? ifVersionAfter, int? level, CancellationToken cancellationToken = default)
         {
             IDictionary<string, string> parameters = new Dictionary<string, string>();
@@ -291,7 +291,8 @@ namespace Smartsheet.Api.Internal
                 parameters.Add("level", level.ToString());
             }
 
-            return this.GetResourceAsync<Sheet>("sheets/" + sheetId + QueryUtil.GenerateUrl(null, parameters), typeof(Sheet), cancellationToken);
+            Sheet sheet = await this.GetResourceAsync<Sheet>("sheets/" + sheetId + QueryUtil.GenerateUrl(null, parameters), typeof(Sheet), cancellationToken).ConfigureAwait(false);
+            return sheet;
         }
 
         /// <summary>
@@ -432,7 +433,33 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual Sheet UpdateSheet(Sheet sheet)
         {
-            return this.UpdateResource("sheets/" + sheet.Id, typeof(Sheet), sheet);
+            var task = UpdateSheetAsync(sheet);
+            task.Wait();
+            return task.Result;
+        }
+
+        /// <summary>
+        /// <para>Asynchronously updates a sheet.</para>
+        /// <para>to modify sheet contents, see Add Rows, Update Rows, and Update Column.</para>
+        /// <para>This operation can be used to update an individual users sheet settings. 
+        /// If the request body contains only the userSettings attribute, 
+        /// this operation may be performed even if the user only has read-only access to the sheet 
+        /// (i.e., the user has viewer permissions, or the sheet is read-only).</para>
+        /// <para>Mirrors to the following Smartsheet REST API method: PUT /sheets/{sheetId}</para>
+        /// </summary>
+        /// <param name="sheet"> the sheet to update </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the updated sheet </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task<Sheet> UpdateSheetAsync(Sheet sheet, CancellationToken cancellationToken = default)
+        {
+            Sheet updatedSheet = await this.UpdateResourceAsync<Sheet>("sheets/" + sheet.Id, typeof(Sheet), sheet, cancellationToken).ConfigureAwait(false);
+            return updatedSheet;
         }
 
         /// <summary>
@@ -473,7 +500,7 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual async Task<int?> GetSheetVersionAsync(long sheetId, CancellationToken cancellationToken = default)
         {
-            Sheet sheet = await this.GetResourceAsync<Sheet>("sheets/" + sheetId + "/version", typeof(Sheet));
+            Sheet sheet = await this.GetResourceAsync<Sheet>("sheets/" + sheetId + "/version", typeof(Sheet), cancellationToken).ConfigureAwait(false);
             return sheet.Version;
         }
 
@@ -492,7 +519,26 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual void SendSheet(long sheetId, SheetEmail email)
         {
-            this.CreateResource<SheetEmail>("sheets/" + sheetId + "/emails", typeof(SheetEmail), email);
+            this.SendSheetAsync(sheetId, email).Wait();
+        }
+
+        /// <summary>
+        /// <para>Asynchronously sends a sheet as a PDF attachment via email to the designated recipients.</para>
+        /// 
+        /// <para>Mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/emails</para>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id </param>
+        /// <param name="email"> the email </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public virtual async Task SendSheetAsync(long sheetId, SheetEmail email, CancellationToken cancellationToken = default)
+        {
+            await this.CreateResourceAsync<SheetEmail>("sheets/" + sheetId + "/emails", typeof(SheetEmail), email, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -576,7 +622,28 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual SheetPublish GetPublishStatus(long sheetId)
         {
-            return this.GetResource<SheetPublish>("sheets/" + sheetId + "/publish", typeof(SheetPublish));
+            var task = GetPublishStatusAsync(sheetId);
+            task.Wait();
+            return task.Result;
+        }
+
+        /// <summary>
+        /// <para>Asynchronously get the status of the publish settings of the sheet, including the URLs of any enabled publishings.</para>
+        /// 
+        /// <para>Mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/publish</para>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the publish status (note that if there is no such resource, this method will throw ResourceNotFoundException rather than returning null) </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task<SheetPublish> GetPublishStatusAsync(long sheetId, CancellationToken cancellationToken = default)
+        {
+            SheetPublish sheetPublish = await this.GetResourceAsync<SheetPublish>("sheets/" + sheetId + "/publish", typeof(SheetPublish), cancellationToken).ConfigureAwait(false);
+            return sheetPublish;
         }
 
         /// <summary>

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/SheetResourcesImpl.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/SheetResourcesImpl.cs
@@ -190,8 +190,65 @@ namespace Smartsheet.Api.Internal
             return this.ListResourcesWithWrapper<Sheet>(path.ToString());
         }
 
-        private IDictionary<string, string> CreateSheetParameters(IEnumerable<SheetLevelInclusion>? includes, IEnumerable<SheetLevelExclusion>? excludes,
+        /// <summary>
+        /// <para>Gets a sheet.</para>
+        /// 
+        /// <para>Mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}</para>
+        /// </summary>
+        /// <param name="sheetId"> the Id of the sheet </param>
+        /// <param name="includes"> used to specify the optional objects to include. </param>
+        /// <param name="excludes"> used to specify the optional objects to include. </param>
+        /// <param name="rowIds"> used to specify the optional objects to include. </param>
+        /// <param name="rowNumbers"> used to specify the optional objects to include. </param>
+        /// <param name="columnIds"> used to specify the optional objects to include. </param>
+        /// <param name="pageSize"> used to specify the optional objects to include. </param>
+        /// <param name="page"> used to specify the optional objects to include. </param>
+        /// <param name="rowsModifiedSince"></param>
+        /// <param name="ifVersionAfter"> only fetch sheet if more recent version available </param>
+        /// <param name="level"> compatibility level </param>
+        /// <returns> the sheet resource (note that if there is no such resource, this method will throw 
+        /// ResourceNotFoundException rather than returning null). </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public virtual Sheet GetSheet(long sheetId, IEnumerable<SheetLevelInclusion>? includes, IEnumerable<SheetLevelExclusion>? excludes,
             IEnumerable<long>? rowIds, IEnumerable<int>? rowNumbers, IEnumerable<long>? columnIds, long? pageSize, long? page, DateTime? rowsModifiedSince, long? ifVersionAfter, int? level)
+        {
+            var task = this.GetSheetAsync(sheetId, includes, excludes, rowIds, rowNumbers, columnIds, pageSize, page, rowsModifiedSince, ifVersionAfter, level);
+            task.Wait();
+            return task.Result;
+        }
+
+        /// <summary>
+        /// <para>Asynchronously gets a sheet.</para>
+        /// 
+        /// <para>Mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}</para>
+        /// </summary>
+        /// <param name="sheetId"> the Id of the sheet </param>
+        /// <param name="includes"> used to specify the optional objects to include. </param>
+        /// <param name="excludes"> used to specify the optional objects to include. </param>
+        /// <param name="rowIds"> used to specify the optional objects to include. </param>
+        /// <param name="rowNumbers"> used to specify the optional objects to include. </param>
+        /// <param name="columnIds"> used to specify the optional objects to include. </param>
+        /// <param name="pageSize"> used to specify the optional objects to include. </param>
+        /// <param name="page"> used to specify the optional objects to include. </param>
+        /// <param name="rowsModifiedSince"></param>
+        /// <param name="ifVersionAfter"> only fetch sheet if more recent version available </param>
+        /// <param name="level"> compatibility level </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the sheet resource (note that if there is no such resource, this method will throw 
+        /// ResourceNotFoundException rather than returning null). </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public virtual Task<Sheet> GetSheetAsync(long sheetId, IEnumerable<SheetLevelInclusion>? includes, IEnumerable<SheetLevelExclusion>? excludes,
+            IEnumerable<long>? rowIds, IEnumerable<int>? rowNumbers, IEnumerable<long>? columnIds, long? pageSize, long? page, DateTime? rowsModifiedSince, long? ifVersionAfter, int? level, CancellationToken cancellationToken = default)
         {
             IDictionary<string, string> parameters = new Dictionary<string, string>();
             if (includes != null)
@@ -234,69 +291,7 @@ namespace Smartsheet.Api.Internal
                 parameters.Add("level", level.ToString());
             }
 
-            return parameters;
-        }
-
-        /// <summary>
-        /// <para>Gets a sheet.</para>
-        /// 
-        /// <para>Mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}</para>
-        /// </summary>
-        /// <param name="sheetId"> the Id of the sheet </param>
-        /// <param name="includes"> used to specify the optional objects to include. </param>
-        /// <param name="excludes"> used to specify the optional objects to include. </param>
-        /// <param name="rowIds"> used to specify the optional objects to include. </param>
-        /// <param name="rowNumbers"> used to specify the optional objects to include. </param>
-        /// <param name="columnIds"> used to specify the optional objects to include. </param>
-        /// <param name="pageSize"> used to specify the optional objects to include. </param>
-        /// <param name="page"> used to specify the optional objects to include. </param>
-        /// <param name="ifVersionAfter"> only fetch sheet if more recent version available </param>
-        /// <param name="level"> compatibility level </param>
-        /// <returns> the sheet resource (note that if there is no such resource, this method will throw 
-        /// ResourceNotFoundException rather than returning null). </returns>
-        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
-        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
-        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
-        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
-        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
-        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
-        public virtual Sheet GetSheet(long sheetId, IEnumerable<SheetLevelInclusion>? includes, IEnumerable<SheetLevelExclusion>? excludes,
-            IEnumerable<long>? rowIds, IEnumerable<int>? rowNumbers, IEnumerable<long>? columnIds, long? pageSize, long? page, DateTime? rowsModifiedSince, long? ifVersionAfter, int? level)
-        {
-            IDictionary<string, string> parameters = CreateSheetParameters(includes, excludes, rowIds, rowNumbers, columnIds, pageSize, page, rowsModifiedSince, ifVersionAfter, level);
-            return this.GetResource<Sheet>("sheets/" + sheetId + QueryUtil.GenerateUrl(null, parameters), typeof(Sheet));
-        }
-
-        /// <summary>
-        /// <para>Asychronously gets a sheet.</para>
-        /// 
-        /// <para>Mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}</para>
-        /// </summary>
-        /// <param name="sheetId"> the Id of the sheet </param>
-        /// <param name="includes"> used to specify the optional objects to include. </param>
-        /// <param name="excludes"> used to specify the optional objects to include. </param>
-        /// <param name="rowIds"> used to specify the optional objects to include. </param>
-        /// <param name="rowNumbers"> used to specify the optional objects to include. </param>
-        /// <param name="columnIds"> used to specify the optional objects to include. </param>
-        /// <param name="pageSize"> used to specify the optional objects to include. </param>
-        /// <param name="page"> used to specify the optional objects to include. </param>
-        /// <param name="rowsModifiedSince"></param>
-        /// <param name="ifVersionAfter"> only fetch sheet if more recent version available </param>
-        /// <param name="level"> compatibility level </param>
-        /// <param name="cancellationToken"> the cancellation token </param>
-        /// <returns> the sheet resource (note that if there is no such resource, this method will throw 
-        /// ResourceNotFoundException rather than returning null). </returns>
-        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
-        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
-        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
-        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
-        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
-        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
-        public virtual Task<Sheet> GetSheetAsync(long sheetId, IEnumerable<SheetLevelInclusion>? includes, IEnumerable<SheetLevelExclusion>? excludes,
-            IEnumerable<long>? rowIds, IEnumerable<int>? rowNumbers, IEnumerable<long>? columnIds, long? pageSize, long? page, DateTime? rowsModifiedSince, long? ifVersionAfter, int? level, CancellationToken cancellationToken = default)
-        {
-            IDictionary<string, string> parameters = CreateSheetParameters(includes, excludes, rowIds, rowNumbers, columnIds, pageSize, page, rowsModifiedSince, ifVersionAfter, level);
-            return this.GetResource<Sheet>("sheets/" + sheetId + QueryUtil.GenerateUrl(null, parameters), typeof(Sheet), cancellationToken);
+            return this.GetResourceAsync<Sheet>("sheets/" + sheetId + QueryUtil.GenerateUrl(null, parameters), typeof(Sheet), cancellationToken);
         }
 
         /// <summary>
@@ -456,7 +451,30 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual int? GetSheetVersion(long sheetId)
         {
-            return this.GetResource<Sheet>("sheets/" + sheetId + "/version", typeof(Sheet)).Version;
+            var task = GetSheetVersionAsync(sheetId);
+            task.Wait();
+            return task.Result;
+        }
+
+        /// <summary>
+        /// <para>Gets the sheet version asynchronously without loading the entire sheet.</para>
+        /// 
+        /// <para>Mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/version</para>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the sheet version (note that if there is no such resource, this method will throw
+        /// ResourceNotFoundException) </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public virtual async Task<int?> GetSheetVersionAsync(long sheetId, CancellationToken cancellationToken = default)
+        {
+            Sheet sheet = await this.GetResourceAsync<Sheet>("sheets/" + sheetId + "/version", typeof(Sheet));
+            return sheet.Version;
         }
 
         /// <summary>

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/SheetResourcesImpl.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/SheetResourcesImpl.cs
@@ -183,7 +183,7 @@ namespace Smartsheet.Api.Internal
                 parameters.Add("modifiedSince", ((DateTime)modifiedSince).ToUniversalTime().ToString("o"));
             }
 
-            PaginatedResult<Sheet> paginatedSheets = await this.ListResourcesWithWrapperAsync<Sheet>("sheets" + QueryUtil.GenerateUrl(null, parameters)).ConfigureAwait(false);
+            PaginatedResult<Sheet> paginatedSheets = await this.ListResourcesWithWrapperAsync<Sheet>("sheets" + QueryUtil.GenerateUrl(null, parameters), cancellationToken).ConfigureAwait(false);
             return paginatedSheets;
         }
 
@@ -221,7 +221,7 @@ namespace Smartsheet.Api.Internal
             {
                 path.Append(paging.ToQueryString());
             }
-            PaginatedResult<Sheet> paginatedSheets = await this.ListResourcesWithWrapperAsync<Sheet>(path.ToString()).ConfigureAwait(false);
+            PaginatedResult<Sheet> paginatedSheets = await this.ListResourcesWithWrapperAsync<Sheet>(path.ToString(), cancellationToken).ConfigureAwait(false);
             return paginatedSheets;
         }
 
@@ -846,6 +846,7 @@ namespace Smartsheet.Api.Internal
         /// <param name="id"> the sheet Id </param>
         /// <param name="sortSpecifier"> the sort criteria </param>
         /// <param name="level"> compatibility level </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
         /// <returns> the sheet (note that if there is no such resource, this method will throw a ResourceNotFoundException rather than returning null). </returns>
         /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
         /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/SheetResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/SheetResources.cs
@@ -23,6 +23,8 @@ using System.Collections.Generic;
 namespace Smartsheet.Api
 {
     using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Api.Models;
 
     /// <summary>
@@ -111,6 +113,45 @@ namespace Smartsheet.Api
                     DateTime? rowsModifiedSince = null,
                     long? ifVersionAfter = null,
                     int? level = null);
+
+        /// <summary>
+        /// <para>Gets a sheet asynchronously.</para>
+        /// 
+        /// <para>Mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}</para>
+        /// </summary>
+        /// <param name="sheetId"> the Id of the sheet </param>
+        /// <param name="includes"> used to specify the optional objects to include. </param>
+        /// <param name="excludes"> used to specify the optional objects to include. </param>
+        /// <param name="rowIds"> used to specify the optional objects to include. </param>
+        /// <param name="rowNumbers"> used to specify the optional objects to include. </param>
+        /// <param name="columnIds"> used to specify the optional objects to include. </param>
+        /// <param name="pageSize"> used to specify the optional objects to include. </param>
+        /// <param name="page"> used to specify the optional objects to include. </param>
+        /// <param name="rowsModifiedSince"></param>
+        /// <param name="ifVersionAfter"></param>
+        /// <param name="level"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns> the sheet resource (note that if there is no such resource, this method will throw 
+        /// ResourceNotFoundException rather than returning null). </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<Sheet> GetSheetAsync(
+                    long sheetId,
+                    IEnumerable<SheetLevelInclusion>? includes = null,
+                    IEnumerable<SheetLevelExclusion>? excludes = null,
+                    IEnumerable<long>? rowIds = null,
+                    IEnumerable<int>? rowNumbers = null,
+                    IEnumerable<long>? columnIds = null,
+                    long? pageSize = null,
+                    long? page = null,
+                    DateTime? rowsModifiedSince = null,
+                    long? ifVersionAfter = null,
+                    int? level = null,
+                    CancellationToken cancellationToken = default);
 
         /// <summary>
         /// <para>Gets a sheet as an Excel file.</para>

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/SheetResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/SheetResources.cs
@@ -93,6 +93,9 @@ namespace Smartsheet.Api
         /// <param name="columnIds"> used to specify the optional objects to include. </param>
         /// <param name="pageSize"> used to specify the optional objects to include. </param>
         /// <param name="page"> used to specify the optional objects to include. </param>
+        /// <param name="rowsModifiedSince"></param>
+        /// <param name="ifVersionAfter"> only fetch sheet if more recent version available </param>
+        /// <param name="level"> compatibility level </param>
         /// <returns> the sheet resource (note that if there is no such resource, this method will throw 
         /// ResourceNotFoundException rather than returning null). </returns>
         /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
@@ -128,9 +131,9 @@ namespace Smartsheet.Api
         /// <param name="pageSize"> used to specify the optional objects to include. </param>
         /// <param name="page"> used to specify the optional objects to include. </param>
         /// <param name="rowsModifiedSince"></param>
-        /// <param name="ifVersionAfter"></param>
-        /// <param name="level"></param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="ifVersionAfter"> only fetch sheet if more recent version available </param>
+        /// <param name="level"> compatibility level </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
         /// <returns> the sheet resource (note that if there is no such resource, this method will throw 
         /// ResourceNotFoundException rather than returning null). </returns>
         /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
@@ -302,6 +305,26 @@ namespace Smartsheet.Api
         Sheet UpdateSheet(Sheet sheet);
 
         /// <summary>
+        /// <para>Updates a sheet.</para>
+        /// <para>To modify sheet contents, see Add Rows, Update Rows, and Update Column.</para>
+        /// <para>This operation can be used to update an individual users sheet settings. 
+        /// If the request body contains only the userSettings attribute, 
+        /// this operation may be performed even if the user only has read-only access to the sheet 
+        /// (i.e., the user has viewer permissions, or the sheet is read-only).</para>
+        /// <para>Mirrors to the following Smartsheet REST API method: PUT /sheets/{sheetId}</para>
+        /// </summary>
+        /// <param name="sheet"> the sheet to update </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the updated sheet </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<Sheet> UpdateSheetAsync(Sheet sheet, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// <para>Gets the sheet version without loading the entire sheet.</para>
         /// 
         /// <para>Mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/version</para>
@@ -318,6 +341,23 @@ namespace Smartsheet.Api
         int? GetSheetVersion(long sheetId);
 
         /// <summary>
+        /// <para>Asynchronously gets the sheet version without loading the entire sheet.</para>
+        /// 
+        /// <para>Mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/version</para>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the sheet version (note that if there is no such resource, this method will throw
+        /// ResourceNotFoundException) </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<int?> GetSheetVersionAsync(long sheetId, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// <para>Sends a sheet as a PDF attachment via email to the designated recipients.</para>
         /// 
         /// <para>Mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/emails</para>
@@ -331,6 +371,22 @@ namespace Smartsheet.Api
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         void SendSheet(long sheetId, SheetEmail email);
+
+        /// <summary>
+        /// <para>Asynchronously sends a sheet as a PDF attachment via email to the designated recipients.</para>
+        /// 
+        /// <para>Mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/emails</para>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id </param>
+        /// <param name="email"> the email </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task SendSheetAsync(long sheetId, SheetEmail email, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// <para>Creates an update request for the specified rows within the sheet. An email notification
@@ -363,6 +419,22 @@ namespace Smartsheet.Api
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         SheetPublish GetPublishStatus(long sheetId);
+
+        /// <summary>
+        /// <para>Asynchronously gets the status of the publish settings of the sheet, including the URLs of any enabled publishings.</para>
+        /// 
+        /// <para>Mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/publish</para>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the publish status (note that if there is no such resource, this method will throw ResourceNotFoundException rather than returning null) </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<SheetPublish> GetPublishStatusAsync(long sheetId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// <para>Sets the publish status of a sheet and returns the new status, including the URLs of any enabled publishings.</para>

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/SheetResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/SheetResources.cs
@@ -64,6 +64,36 @@ namespace Smartsheet.Api
         PaginatedResult<Sheet> ListSheets(IEnumerable<SheetInclusion>? includes = null, PaginationParameters? paging = null, DateTime? modifiedSince = null);
 
         /// <summary>
+        /// <para>Asynchronously gets the list of all sheets that the user has access to, in alphabetical order, by name.</para>
+        /// 
+        /// <para>Mirrors to the following Smartsheet REST API method: GET /Sheets</para>
+        /// </summary>
+        /// <param name="includes">elements to include in response</param>
+        /// <param name="paging">the pagination</param>
+        /// <param name="modifiedSince">only return sheets modified on or after the specified date</param>
+        /// <param name="cancellationToken">the cancellation token</param>
+        /// <returns> A list of all sheets (note that an empty list will be returned if there are none) limited to the following attributes:
+        /// <list type="bullet">
+        /// <item><description>id</description></item>
+        /// <item><description>name</description></item>
+        /// <item><description>accessLevel</description></item>
+        /// <item><description>permalink</description></item>
+        /// <item><description>source (included only if "source" is specified with the include parameter)</description></item>
+        /// <item><description>owner (included only if "ownerInfo" is specified with the include parameter)</description></item>
+        /// <item><description>ownerId (included only if "ownerInfo" is specified with the include parameter)</description></item>
+        /// <item><description>createdAt</description></item>
+        /// <item><description>modifiedAt</description></item>
+        /// </list>
+        /// </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<PaginatedResult<Sheet>> ListSheetsAsync(IEnumerable<SheetInclusion>? includes = null, PaginationParameters? paging = null, DateTime? modifiedSince = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// <para>Lists all sheets in the organization.</para>
         /// 
         /// <para>Mirrors to the following Smartsheet REST API method: GET /users/sheets</para>
@@ -238,6 +268,23 @@ namespace Smartsheet.Api
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         Sheet CreateSheetFromTemplate(Sheet sheet, IEnumerable<TemplateInclusion>? include = null);
 
+        /// <summary>
+        /// <para>Asynchronously creates a sheet (from existing sheet or template) in default "Sheets" collection.</para>
+        /// 
+        /// <para>Mirrors to the following Smartsheet REST API method: POST /Sheets</para>
+        /// </summary>
+        /// <param name="sheet"> the sheet to create </param>
+        /// <param name="include"> used to specify the optional objects to include. </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the created sheet </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<Sheet> CreateSheetFromTemplateAsync(Sheet sheet, IEnumerable<TemplateInclusion>? include = null, CancellationToken cancellationToken = default);
+
         ///// <summary>
         ///// <para>Creates a sheet in given folder.</para>
         ///// 
@@ -286,6 +333,21 @@ namespace Smartsheet.Api
         void DeleteSheet(long sheetId);
 
         /// <summary>
+        /// <para>Asynchronously deletes a sheet.</para>
+        /// 
+        /// <para>Mirrors to the following Smartsheet REST API method: DELETE /sheets/{sheetId}</para>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task DeleteSheetAsync(long sheetId, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// <para>Updates a sheet.</para>
         /// <para>To modify sheet contents, see Add Rows, Update Rows, and Update Column.</para>
         /// <para>This operation can be used to update an individual users sheet settings. 
@@ -305,7 +367,7 @@ namespace Smartsheet.Api
         Sheet UpdateSheet(Sheet sheet);
 
         /// <summary>
-        /// <para>Updates a sheet.</para>
+        /// <para>Asynchronously updates a sheet.</para>
         /// <para>To modify sheet contents, see Add Rows, Update Rows, and Update Column.</para>
         /// <para>This operation can be used to update an individual users sheet settings. 
         /// If the request body contains only the userSettings attribute, 
@@ -454,6 +516,24 @@ namespace Smartsheet.Api
         SheetPublish UpdatePublishStatus(long sheetId, SheetPublish publish);
 
         /// <summary>
+        /// <para>Asynchronously sets the publish status of a sheet and returns the new status, including the URLs of any enabled publishings.</para>
+        /// 
+        /// <para>Mirrors to the following Smartsheet REST API method: PUT /sheets/{sheetId}/publish</para>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id </param>
+        /// <param name="publish"> the SheetPublish object limited. </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the update SheetPublish object (note that if there is no such resource, this method will throw a 
+        /// ResourceNotFoundException rather than returning null). </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<SheetPublish> UpdatePublishStatusAsync(long sheetId, SheetPublish publish, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// <para>Creates a copy of the specified sheet.</para>
         /// <para>Mirrors to the following Smartsheet REST API method:<br />
         /// POST /sheets/{sheetId}/copy</para>
@@ -472,6 +552,25 @@ namespace Smartsheet.Api
         Sheet CopySheet(long sheetId, ContainerDestination destination, IEnumerable<SheetCopyInclusion>? include = null, IEnumerable<SheetCopyExclusion>? exclude = null);
 
         /// <summary>
+        /// <para>Asynchronously creates a copy of the specified sheet.</para>
+        /// <para>Mirrors to the following Smartsheet REST API method:<br />
+        /// POST /sheets/{sheetId}/copy</para>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id </param>
+        /// <param name="destination"> the destination to copy to </param>
+        /// <param name="include"> the elements to copy. Note: Cell history will not be copied, regardless of which include parameter values are specified.</param>
+        /// <param name="exclude"> optional elements to exclude </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the created folder </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<Sheet> CopySheetAsync(long sheetId, ContainerDestination destination, IEnumerable<SheetCopyInclusion>? include = null, IEnumerable<SheetCopyExclusion>? exclude = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// <para>Moves the specified sheet to a new location.</para>
         /// <para>Mirrors to the following Smartsheet REST API method:<br />
         /// POST /sheets/{sheetId}/move</para>
@@ -486,6 +585,23 @@ namespace Smartsheet.Api
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         Sheet MoveSheet(long sheetId, ContainerDestination destination);
+
+        /// <summary>
+        /// <para>Asynchronously moves the specified sheet to a new location.</para>
+        /// <para>Mirrors to the following Smartsheet REST API method:<br />
+        /// POST /sheets/{sheetId}/move</para>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id </param>
+        /// <param name="destination"> the destination to copy to </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the moved sheet </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<Sheet> MoveSheetAsync(long sheetId, ContainerDestination destination, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// <para>Sorts a sheet according to the sort criteria.</para>
@@ -503,6 +619,24 @@ namespace Smartsheet.Api
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         Sheet SortSheet(long sheetId, SortSpecifier sortSpecifier, int? level= null);
+
+        /// <summary>
+        /// <para>Asynchronously sorts a sheet according to the sort criteria.</para>
+        /// 
+        /// <para>Mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/sort</para>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id </param>
+        /// <param name="sortSpecifier"> the sort criteria </param>
+        /// <param name="level"> compatibility level </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the Sheet (note that if there is no such resource, this method will throw a ResourceNotFoundException rather than returning null). </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<Sheet> SortSheetAsync(long sheetId, SortSpecifier sortSpecifier, int? level= null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// <para>Imports a sheet (from CSV). </para>


### PR DESCRIPTION
This is a WIP PR for adding async overrides/methods for common resource implementations, in reference to https://github.com/smartsheet/smartsheet-csharp-sdk/discussions/193

**Changes**
- `RequestAsync` method and overrides within `DefaultHttpClient.cs` access modifiers changed to public so that it can be used in our async methods within resource implementations.
- A `CancellationToken` argument was added to the end of `RequestAsync` within `DefaultHttpClient.cs`. The idea is to expose the ability to cancel any async requests to the user.

**Additions**
- Async override for `GetResource` created within `AbstractResources.cs`. This function is largely the same as the original, so it could probably be further abstracted or split into helper functions to be used in both the original and this new override to avoid rewriting code.
- `GetSheetAsync` method -- a version of `GetSheet` that uses the async override for `GetResource` -- was added.
- The code to create the request parameters for `GetSheet` and `GetSheetAsync` was consolidated into a private `CreateSheetParameters` function within `SheetResourceImpl.cs` -- again, the idea was to eliminate rewriting that code for what is largely the same method but async.

Any advice, requests, or changes welcome! I think most resource implementations could receive async versions of their methods if something similar to what I have here is implemented.

After some recommendations I could add the rest of the async methods/overrides.