### PR TITLE
Add async methods for sheet row resources + report resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added support for GET /2.0/sights/{sightId}/path endpoint (`GetSightPath`)
 - Added support for GET /2.0/folders/{folderId}/path endpoint (`GetFolderPath`)
 - Added helper methods `GetLeaf<Asset>()` and `GetLeaf<Asset>Path()` to the responses of the path endpoints for convenient traversal
+- Added asynchronous (`*Async`) counterparts to `SheetResources.RowResources`: `AddRowsAsync`, `AddRowsAllowPartialSuccessAsync`, `GetRowAsync`, `CopyRowsToAnotherSheetAsync`, `DeleteRowsAsync`, `MoveRowsToAnotherSheetAsync`, `SendRowsAsync`, `CreateResourceAsync`, `UpdateRowsAsync`, and `UpdateRowsAllowPartialSuccessAsync`.
+- Added asynchronous (`*Async`) counterparts to `ReportResources`: `GetReportAsync`, `ListReportsAsync`, `SendReportAsync`, `DeleteReportAsync`, `GetPublishStatusAsync`, `UpdatePublishStatusAsync`, `UpdateReportDefinitionAsync`, `AddReportScopeAsync`, `RemoveReportScopeAsync`, `AddReportColumnsAsync`, `CreateReportAsync`, and `GetReportPathAsync`.
 
 ## [7.0.0] - 2026-06-08
 

--- a/mock-api-test-sdk-net80/RowAsyncTests.cs
+++ b/mock-api-test-sdk-net80/RowAsyncTests.cs
@@ -172,7 +172,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task AddRowsAsync_AssignValues_Hyperlink()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Assign Values - Hyperlink");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Assign Values - Hyperlink");
 
             Row rowA = new Row
             {

--- a/mock-api-test-sdk-net80/RowAsyncTests.cs
+++ b/mock-api-test-sdk-net80/RowAsyncTests.cs
@@ -208,7 +208,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task AddRowsAsync_AssignValues_HyperlinkSheetID()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Assign Values - Hyperlink SheetID");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Assign Values - Hyperlink SheetID");
 
             Row rowA = new Row
             {

--- a/mock-api-test-sdk-net80/RowAsyncTests.cs
+++ b/mock-api-test-sdk-net80/RowAsyncTests.cs
@@ -55,7 +55,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task AddRowsAsync_AssignValues_Int()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Assign Values - Int");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Assign Values - Int");
 
             Row rowA = new Row
             {

--- a/mock-api-test-sdk-net80/RowAsyncTests.cs
+++ b/mock-api-test-sdk-net80/RowAsyncTests.cs
@@ -10,7 +10,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task AddRowsAsync_AssignValues_String()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Assign Values - String");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Assign Values - String");
 
             Row rowA = new Row
             {

--- a/mock-api-test-sdk-net80/RowAsyncTests.cs
+++ b/mock-api-test-sdk-net80/RowAsyncTests.cs
@@ -970,7 +970,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task MoveRowAsync_AnotherSheet()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Move row to another sheet (async)");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Move row to another sheet");
 
             CopyOrMoveRowResult result = await smartsheet.SheetResources.RowResources.MoveRowsToAnotherSheetAsync(
                 1228520367122308,

--- a/mock-api-test-sdk-net80/RowAsyncTests.cs
+++ b/mock-api-test-sdk-net80/RowAsyncTests.cs
@@ -145,7 +145,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task AddRowsAsync_AssignFormulae()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Assign Formulae");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Assign Formulae");
 
             Row rowA = new Row
             {

--- a/mock-api-test-sdk-net80/RowAsyncTests.cs
+++ b/mock-api-test-sdk-net80/RowAsyncTests.cs
@@ -244,7 +244,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task AddRowsAsync_AssignValues_HyperlinkReportID()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Assign Values - Hyperlink ReportID");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Assign Values - Hyperlink ReportID");
 
             Row rowA = new Row
             {
@@ -280,7 +280,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task AddRowsAsync_Invalid_AssignValueAndFormulae()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Invalid - Assign Value and Formulae");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Invalid - Assign Value and Formulae");
 
             Row rowA = new Row
             {
@@ -307,7 +307,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task AddRowsAsync_Invalid_AssignHyperlinkUrlandSheetId()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Invalid - Assign Hyperlink URL and SheetId");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Invalid - Assign Hyperlink URL and SheetId");
 
             Row rowA = new Row
             {
@@ -340,7 +340,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task AddRowsAsync_AssignObjectValue_PredecessorList()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Assign Object Value - Predecessor List (using floats)");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Assign Object Value - Predecessor List (using floats)");
 
             Row rowA = new Row
             {
@@ -377,7 +377,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task AddRowsAsync_Location_Top()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Location - Top");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Location - Top");
 
             Row rowA = new Row
             {
@@ -409,7 +409,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task AddRowsAsync_Location_Bottom()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Location - Bottom");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Location - Bottom");
 
             Row rowA = new Row
             {
@@ -441,7 +441,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task UpdateRowsAsync_AssignValues_String()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Assign Values - String");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Assign Values - String");
 
             Row rowA = new Row
             {
@@ -487,7 +487,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task UpdateRowsAsync_AssignValues_Int()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Assign Values - Int");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Assign Values - Int");
 
             Row rowA = new Row
             {
@@ -532,7 +532,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task UpdateRowsAsync_AssignValues_Bool()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Assign Values - Bool");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Assign Values - Bool");
 
             Row rowA = new Row
             {
@@ -643,7 +643,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task UpdateRowsAsync_AssignValues_HyperlinkSheetID()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Assign Values - Hyperlink SheetID");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Assign Values - Hyperlink SheetID");
 
             Row rowA = new Row
             {
@@ -681,7 +681,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task UpdateRowsAsync_AssignValues_HyperlinkReportID()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Assign Values - Hyperlink ReportID");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Assign Values - Hyperlink ReportID");
 
             Row rowA = new Row
             {
@@ -718,7 +718,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task UpdateRowsAsync_Invalid_AssignValueAndFormulae()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Invalid - Assign Value and Formulae");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Invalid - Assign Value and Formulae");
 
             Row rowA = new Row
             {
@@ -746,7 +746,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task UpdateRowsAsync_Invalid_AssignHyperlinkUrlandSheetId()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Invalid - Assign Hyperlink URL and SheetId");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Invalid - Assign Hyperlink URL and SheetId");
 
             Row rowA = new Row
             {
@@ -779,7 +779,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task UpdateRowsAsync_ClearValue_TextNumber()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Clear Value - Text Number");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Clear Value - Text Number");
 
             Row rowA = new Row
             {
@@ -803,7 +803,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task UpdateRowsAsync_ClearValue_Checkbox()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Clear Value - Checkbox");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Clear Value - Checkbox");
 
             Row rowA = new Row
             {
@@ -827,7 +827,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task UpdateRowsAsync_ClearValue_Hyperlink()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Clear Value - Hyperlink");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Clear Value - Hyperlink");
 
             Row rowA = new Row
             {
@@ -853,7 +853,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task UpdateRowsAsync_ClearValue_CellLink()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Clear Value - Cell Link");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Clear Value - Cell Link");
 
             Row rowA = new Row
             {
@@ -879,7 +879,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task UpdateRowsAsync_ClearValue_PredecessorList()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Clear Value - Predecessor List");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Clear Value - Predecessor List");
 
             Row rowA = new Row
             {
@@ -903,7 +903,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task UpdateRowsAsync_Invalid_AssignHyperlinkAndCellLink()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Invalid - Assign Hyperlink and Cell Link");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Invalid - Assign Hyperlink and Cell Link");
 
             Row rowA = new Row
             {
@@ -936,7 +936,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task UpdateRowsAsync_Location_Top()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Location - Top");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Location - Top");
 
             Row rowA = new Row
             {
@@ -953,7 +953,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task UpdateRowsAsync_Location_Bottom()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Location - Bottom");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Location - Bottom");
 
             Row rowA = new Row
             {

--- a/mock-api-test-sdk-net80/RowAsyncTests.cs
+++ b/mock-api-test-sdk-net80/RowAsyncTests.cs
@@ -991,7 +991,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task CopyRowAsync_AnotherSheet()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Copy row to another sheet (async)");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Copy row to another sheet");
             CopyOrMoveRowResult result = await smartsheet.SheetResources.RowResources.CopyRowsToAnotherSheetAsync(
                 1228520367122308,
                 new CopyOrMoveRowDirective

--- a/mock-api-test-sdk-net80/RowAsyncTests.cs
+++ b/mock-api-test-sdk-net80/RowAsyncTests.cs
@@ -1,0 +1,1011 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Smartsheet.Api;
+using Smartsheet.Api.Models;
+
+namespace mock_api_test_sdk_net80
+{
+    [TestClass]
+    public class RowAsyncTests
+    {
+        [TestMethod]
+        public async Task AddRowsAsync_AssignValues_String()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Assign Values - String");
+
+            Row rowA = new Row
+            {
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = "Apple"
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "Red Fruit"
+                    }
+                }
+            };
+
+            Row rowB = new Row
+            {
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = "Banana"
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "Yellow Fruit"
+                    }
+                }
+            };
+
+            // Update rows in sheet
+            IList<Row> addedRows = await smartsheet.SheetResources.RowResources.AddRowsAsync(1, new Row[] { rowA, rowB });
+
+            Row? row = addedRows.FirstOrDefault(r => r.Id == 10);
+            Cell? cell = row?.Cells.FirstOrDefault(c => c.Value.Equals("Apple"));
+
+            Assert.IsNotNull(cell);
+            Assert.AreEqual(101, cell.ColumnId);
+        }
+
+        [TestMethod]
+        public async Task AddRowsAsync_AssignValues_Int()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Assign Values - Int");
+
+            Row rowA = new Row
+            {
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = 100
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "One Hundred"
+                    }
+                }
+            };
+
+            Row rowB = new Row
+            {
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = 2.1
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "Two Point One"
+                    }
+                }
+            };
+
+            // Update rows in sheet
+            IList<Row> addedRows = await smartsheet.SheetResources.RowResources.AddRowsAsync(1, new Row[] { rowA, rowB });
+
+            Row? row = addedRows.FirstOrDefault(r => r.Id == 10);
+            Cell? cell = row?.Cells.FirstOrDefault(c => Convert.ToInt32(c.Value) == 100);
+            Assert.IsNotNull(cell);
+            Assert.AreEqual(101, cell.ColumnId);
+        }
+
+        [TestMethod]
+        public async Task AddRowsAsync_AssignValues_Bool()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Assign Values - Bool");
+
+            Row rowA = new Row
+            {
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = true
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "This is True"
+                    }
+                }
+            };
+
+            Row rowB = new Row
+            {
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = false
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "This is False"
+                    }
+                }
+            };
+
+            // Update rows in sheet
+            IList<Row> addedRows = await smartsheet.SheetResources.RowResources.AddRowsAsync(1, new Row[] { rowA, rowB });
+
+            Row? row = addedRows.FirstOrDefault(r => r.Id == 10);
+            Cell? cell = row?.Cells.FirstOrDefault(c => c.Value.Equals(true));
+
+            Assert.IsNotNull(cell);
+            Assert.AreEqual(101, cell.ColumnId);
+        }
+
+
+        [TestMethod]
+        public async Task AddRowsAsync_AssignFormulae()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Assign Formulae");
+
+            Row rowA = new Row
+            {
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Formula = "=SUM([Column2]3, [Column2]4)*2"
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Formula = "=SUM([Column2]3, [Column2]3, [Column2]4)"
+                    }
+                }
+            };
+
+            IList<Row> addedRows = await smartsheet.SheetResources.RowResources.AddRowsAsync(1, new Row[] { rowA });
+
+            Cell? cell = addedRows[0].Cells.FirstOrDefault(c => c.Formula.Equals("=SUM([Column2]3, [Column2]3, [Column2]4)"));
+            Assert.IsNotNull(cell);
+            Assert.AreEqual(102, cell.ColumnId);
+        }
+
+        [TestMethod]
+        public async Task AddRowsAsync_AssignValues_Hyperlink()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Assign Values - Hyperlink");
+
+            Row rowA = new Row
+            {
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = "Google",
+                        Hyperlink = new Hyperlink{
+                            Url = "http://google.com"
+                        }
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "Bing",
+                        Hyperlink = new Hyperlink{
+                            Url = "http://bing.com"
+                        }
+                    }
+                }
+            };
+
+            IList<Row> addedRows = await smartsheet.SheetResources.RowResources.AddRowsAsync(1, new Row[] { rowA });
+
+            Cell? cell = addedRows[0].Cells.FirstOrDefault(c => c.Value.Equals("Google"));
+            Assert.IsNotNull(cell);
+            Hyperlink link = cell.Hyperlink;
+
+            Assert.AreEqual(101, cell.ColumnId);
+            Assert.AreEqual("http://google.com", link.Url);
+        }
+
+        [TestMethod]
+        public async Task AddRowsAsync_AssignValues_HyperlinkSheetID()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Assign Values - Hyperlink SheetID");
+
+            Row rowA = new Row
+            {
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = "Sheet2",
+                        Hyperlink = new Hyperlink{
+                            SheetId = 2
+                        }
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "Sheet3",
+                        Hyperlink = new Hyperlink{
+                            SheetId = 3
+                        }
+                    }
+                }
+            };
+
+            IList<Row> addedRows = await smartsheet.SheetResources.RowResources.AddRowsAsync(1, new Row[] { rowA });
+            var cellsValue = addedRows[0].Cells;
+            Cell? cell = cellsValue.FirstOrDefault(c => c.Value.Equals("Sheet3"));
+            Assert.IsNotNull(cell);
+            Hyperlink link = cell.Hyperlink;
+
+            Assert.AreEqual(102, cell.ColumnId);
+            Assert.AreEqual(3, link.SheetId);
+        }
+
+        [TestMethod]
+        public async Task AddRowsAsync_AssignValues_HyperlinkReportID()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Assign Values - Hyperlink ReportID");
+
+            Row rowA = new Row
+            {
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = "Report9",
+                        Hyperlink = new Hyperlink{
+                            ReportId = 9
+                        }
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "Report8",
+                        Hyperlink = new Hyperlink{
+                            ReportId = 8
+                        }
+                    }
+                }
+            };
+
+            IList<Row> addedRows = await smartsheet.SheetResources.RowResources.AddRowsAsync(1, new Row[] { rowA });
+
+            Cell? cell = addedRows[0].Cells.FirstOrDefault(c => c.Value.Equals("Report8"));
+            Assert.IsNotNull(cell);
+            Hyperlink link = cell.Hyperlink;
+
+            Assert.AreEqual(102, cell.ColumnId);
+            Assert.AreEqual(8, link.ReportId);
+        }
+
+        [TestMethod]
+        public async Task AddRowsAsync_Invalid_AssignValueAndFormulae()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Invalid - Assign Value and Formulae");
+
+            Row rowA = new Row
+            {
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Formula = "=SUM([Column2]3, [Column2]4)*2",
+                        Value = "20"
+
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Formula = "=SUM([Column2]3, [Column2]3, [Column2]4)"
+                    }
+                }
+            };
+
+            await HelperFunctions.AssertRaisesExceptionAsync<SmartsheetException>(() =>
+                smartsheet.SheetResources.RowResources.AddRowsAsync(1, new Row[] { rowA }),
+                "If cell.formula is specified, then value, objectValue, image, hyperlink, and linkInFromCell must not be specified.");
+        }
+
+        [TestMethod]
+        public async Task AddRowsAsync_Invalid_AssignHyperlinkUrlandSheetId()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Invalid - Assign Hyperlink URL and SheetId");
+
+            Row rowA = new Row
+            {
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = "Google",
+                        Hyperlink = new Hyperlink{
+                            Url = "http://google.com",
+                            SheetId = 2
+                        }
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "Bing",
+                        Hyperlink = new Hyperlink{
+                            Url = "http://bing.com"
+                        }
+                    }
+                }
+            };
+
+
+            await HelperFunctions.AssertRaisesExceptionAsync<SmartsheetException>(() =>
+                smartsheet.SheetResources.RowResources.AddRowsAsync(1, new Row[] { rowA }),
+                "hyperlink.url must be null for sheet, report, or Sight hyperlinks.");
+        }
+
+        [TestMethod]
+        public async Task AddRowsAsync_AssignObjectValue_PredecessorList()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Assign Object Value - Predecessor List (using floats)");
+
+            Row rowA = new Row
+            {
+                Cells = new List<Cell>
+                {
+                    new Cell
+                    {
+                        ColumnId = 101,
+                        ObjectValue = new PredecessorList
+                        {
+                            Predecessors = new List<Predecessor>
+                            {
+                                new Predecessor
+                                {
+                                    RowId = 10,
+                                    Type = "FS",
+                                    Lag = new Duration
+                                    {
+                                        Days = 2.5
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            IList<Row> addedRows = await smartsheet.SheetResources.RowResources.AddRowsAsync(1, new Row[] { rowA });
+
+            Cell predecessorCell = addedRows[0].Cells.Single(c => c.ColumnId == 101);
+            Assert.AreEqual("2FS +2.5d", predecessorCell.Value);
+        }
+
+        [TestMethod]
+        public async Task AddRowsAsync_Location_Top()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Location - Top");
+
+            Row rowA = new Row
+            {
+                ToTop = true,
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = "Apple"
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "Red Fruit"
+                    }
+                }
+            };
+
+            // Update rows in sheet
+            IList<Row> addedRows = await smartsheet.SheetResources.RowResources.AddRowsAsync(1, new Row[] { rowA });
+
+            Row? row = addedRows.FirstOrDefault(r => r.Id == 10);
+            Cell? cell = row?.Cells.FirstOrDefault(c => c.Value.Equals("Apple"));
+
+            Assert.AreEqual(1, row?.RowNumber);
+            Assert.IsNotNull(cell);
+            Assert.AreEqual(101, cell.ColumnId);
+        }
+
+        [TestMethod]
+        public async Task AddRowsAsync_Location_Bottom()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Location - Bottom");
+
+            Row rowA = new Row
+            {
+                ToBottom = true,
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = "Apple"
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "Red Fruit"
+                    }
+                }
+            };
+
+            // Update rows in sheet
+            IList<Row> addedRows = await smartsheet.SheetResources.RowResources.AddRowsAsync(1, new Row[] { rowA });
+
+            Row? row = addedRows.FirstOrDefault(r => r.Id == 10);
+            Cell? cell = row?.Cells.FirstOrDefault(c => c.Value.Equals("Apple"));
+
+            Assert.AreEqual(100, row?.RowNumber);
+            Assert.IsNotNull(cell);
+            Assert.AreEqual(101, cell.ColumnId);
+        }
+
+        [TestMethod]
+        public async Task UpdateRowsAsync_AssignValues_String()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Assign Values - String");
+
+            Row rowA = new Row
+            {
+                Id = 10,
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = "Apple"
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "Red Fruit"
+                    }
+                }
+            };
+
+            Row rowB = new Row
+            {
+                Id = 11,
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = "Banana"
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "Yellow Fruit"
+                    }
+                }
+            };
+
+            // Update rows in sheet
+            IList<Row> updatedRows = await smartsheet.SheetResources.RowResources.UpdateRowsAsync(1, new Row[] { rowA, rowB });
+
+            Row? row = updatedRows.Where(r => r.Id == 10).FirstOrDefault();
+            Cell? cell = row?.Cells.Where(c => c.Value.Equals("Apple")).FirstOrDefault();
+            Assert.IsNotNull(cell);
+            Assert.AreEqual(101, cell.ColumnId);
+        }
+
+        [TestMethod]
+        public async Task UpdateRowsAsync_AssignValues_Int()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Assign Values - Int");
+
+            Row rowA = new Row
+            {
+                Id = 10,
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = 100
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "One Hundred"
+                    }
+                }
+            };
+
+            Row rowB = new Row
+            {
+                Id = 11,
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = 2.1
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "Two Point One"
+                    }
+                }
+            };
+
+            // Update rows in sheet
+            IList<Row> updatedRows = await smartsheet.SheetResources.RowResources.UpdateRowsAsync(1, [rowA, rowB]);
+            Row? row = updatedRows.FirstOrDefault(r => r.Id == 10);
+            Cell? cell = row?.Cells.FirstOrDefault(c => Convert.ToInt32(c.Value) == 100);
+            Assert.IsNotNull(cell);
+            Assert.AreEqual(101, cell.ColumnId);
+        }
+
+        [TestMethod]
+        public async Task UpdateRowsAsync_AssignValues_Bool()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Assign Values - Bool");
+
+            Row rowA = new Row
+            {
+                Id = 10,
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = true
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "This is True"
+                    }
+                }
+            };
+
+            Row rowB = new Row
+            {
+                Id = 11,
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = false
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "This is False"
+                    }
+                }
+            };
+
+            // Update rows in sheet
+            IList<Row> updatedRows = await smartsheet.SheetResources.RowResources.UpdateRowsAsync(1, new Row[] { rowA, rowB });
+
+            Row? row = updatedRows.FirstOrDefault(r => r.Id == 10);
+            Cell? cell = row?.Cells.FirstOrDefault(c => c.Value.Equals(true));
+            Assert.IsNotNull(cell);
+            Assert.AreEqual(101, cell.ColumnId);
+        }
+
+        [TestMethod]
+        public async Task UpdateRows_AssignFormulae()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Assign Formulae");
+
+            Row rowA = new Row
+            {
+                Id = 11,
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Formula = "=SUM([Column2]3, [Column2]4)*2"
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Formula = "=SUM([Column2]3, [Column2]3, [Column2]4)"
+                    }
+                }
+            };
+
+            IList<Row> updatedRows = await smartsheet.SheetResources.RowResources.UpdateRowsAsync(1, new Row[] { rowA });
+
+            Cell? cell = updatedRows[0].Cells.Where(c => c.Formula.Equals("=SUM([Column2]3, [Column2]3, [Column2]4)")).FirstOrDefault();
+            Assert.IsNotNull(cell);
+            Assert.AreEqual(102, cell.ColumnId);
+        }
+
+        [TestMethod]
+        public async Task UpdateRows_AssignValues_Hyperlink()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows - Assign Values - Hyperlink");
+
+            Row rowA = new Row
+            {
+                Id = 10,
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = "Google",
+                        Hyperlink = new Hyperlink{
+                            Url = "http://google.com"
+                        }
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "Bing",
+                        Hyperlink = new Hyperlink{
+                            Url = "http://bing.com"
+                        }
+                    }
+                }
+            };
+
+            IList<Row> updatedRows = await smartsheet.SheetResources.RowResources.UpdateRowsAsync(1, new Row[] { rowA });
+
+            Cell? cell = updatedRows[0].Cells.Where(c => c.Value.Equals("Google")).FirstOrDefault();
+            Assert.IsNotNull(cell);
+            Hyperlink link = cell.Hyperlink;
+
+            Assert.AreEqual(101, cell.ColumnId);
+            Assert.AreEqual("http://google.com", link.Url);
+        }
+
+        [TestMethod]
+        public async Task UpdateRowsAsync_AssignValues_HyperlinkSheetID()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Assign Values - Hyperlink SheetID");
+
+            Row rowA = new Row
+            {
+                Id = 10,
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = "Sheet2",
+                        Hyperlink = new Hyperlink{
+                            SheetId = 2
+                        }
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "Sheet3",
+                        Hyperlink = new Hyperlink{
+                            SheetId = 3
+                        }
+                    }
+                }
+            };
+
+            IList<Row> updatedRows = await smartsheet.SheetResources.RowResources.UpdateRowsAsync(1, new Row[] { rowA });
+            var cells = updatedRows[0].Cells;
+            Assert.IsNotNull(cells);
+            Cell? cell = cells.FirstOrDefault(c => c.Value.Equals("Sheet3"));
+            Assert.IsNotNull(cell);
+            Hyperlink link = cell.Hyperlink;
+
+            Assert.AreEqual(102, cell.ColumnId);
+            Assert.AreEqual(3, link.SheetId);
+        }
+
+        [TestMethod]
+        public async Task UpdateRowsAsync_AssignValues_HyperlinkReportID()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Assign Values - Hyperlink ReportID");
+
+            Row rowA = new Row
+            {
+                Id = 10,
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = "Report9",
+                        Hyperlink = new Hyperlink{
+                            ReportId = 9
+                        }
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "Report8",
+                        Hyperlink = new Hyperlink{
+                            ReportId = 8
+                        }
+                    }
+                }
+            };
+
+            IList<Row> updatedRows = await smartsheet.SheetResources.RowResources.UpdateRowsAsync(1, new Row[] { rowA });
+
+            Cell? cell = updatedRows[0].Cells.FirstOrDefault(c => c.Value.Equals("Report8"));
+            Assert.IsNotNull(cell);
+            Hyperlink link = cell.Hyperlink;
+
+            Assert.AreEqual(102, cell.ColumnId);
+            Assert.AreEqual(8, link.ReportId);
+        }
+
+        [TestMethod]
+        public async Task UpdateRowsAsync_Invalid_AssignValueAndFormulae()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Invalid - Assign Value and Formulae");
+
+            Row rowA = new Row
+            {
+                Id = 10,
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Formula = "=SUM([Column2]3, [Column2]4)*2",
+                        Value = "20"
+
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Formula = "=SUM([Column2]3, [Column2]3, [Column2]4)"
+                    }
+                }
+            };
+
+            await HelperFunctions.AssertRaisesExceptionAsync<SmartsheetException>(() =>
+                smartsheet.SheetResources.RowResources.UpdateRowsAsync(1, new Row[] { rowA }),
+                "If cell.formula is specified, then value, objectValue, image, hyperlink, and linkInFromCell must not be specified.");
+        }
+
+        [TestMethod]
+        public async Task UpdateRowsAsync_Invalid_AssignHyperlinkUrlandSheetId()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Invalid - Assign Hyperlink URL and SheetId");
+
+            Row rowA = new Row
+            {
+                Id = 10,
+                Cells = new List<Cell>
+                {
+                    new Cell{
+                        ColumnId = 101,
+                        Value = "Google",
+                        Hyperlink = new Hyperlink{
+                            Url = "http://google.com",
+                            SheetId = 2
+                        }
+                    },
+                    new Cell{
+                        ColumnId = 102,
+                        Value = "Bing",
+                        Hyperlink = new Hyperlink{
+                            Url = "http://bing.com"
+                        }
+                    }
+                }
+            };
+
+            await HelperFunctions.AssertRaisesExceptionAsync<SmartsheetException>(() =>
+                smartsheet.SheetResources.RowResources.UpdateRowsAsync(1, new Row[] { rowA }),
+                "hyperlink.url must be null for sheet, report, or Sight hyperlinks.");
+        }
+
+        [TestMethod]
+        public async Task UpdateRowsAsync_ClearValue_TextNumber()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Clear Value - Text Number");
+
+            Row rowA = new Row
+            {
+                Id = 10,
+                Cells = new List<Cell>
+                {
+                    new Cell
+                    {
+                        ColumnId = 101,
+                        Value = ""
+                    }
+                }
+            };
+
+            IList<Row> updatedRows = await smartsheet.SheetResources.RowResources.UpdateRowsAsync(1, new Row[] { rowA });
+
+            Cell updatedCell = updatedRows[0].Cells.Single(c => c.ColumnId == 101);
+            Assert.AreEqual(null, updatedCell.Value);
+        }
+
+        [TestMethod]
+        public async Task UpdateRowsAsync_ClearValue_Checkbox()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Clear Value - Checkbox");
+
+            Row rowA = new Row
+            {
+                Id = 10,
+                Cells = new List<Cell>
+                {
+                    new Cell
+                    {
+                        ColumnId = 101,
+                        Value = ""
+                    }
+                }
+            };
+
+            IList<Row> updatedRows = await smartsheet.SheetResources.RowResources.UpdateRowsAsync(1, new Row[] { rowA });
+
+            Cell updatedCell = updatedRows[0].Cells.Single(c => c.ColumnId == 101);
+            Assert.AreEqual(false, updatedCell.Value);
+        }
+
+        [TestMethod]
+        public async Task UpdateRowsAsync_ClearValue_Hyperlink()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Clear Value - Hyperlink");
+
+            Row rowA = new Row
+            {
+                Id = 10,
+                Cells = new List<Cell>
+                {
+                    new Cell
+                    {
+                        ColumnId = 101,
+                        Value = "",
+                        Hyperlink = new Hyperlink()
+                    }
+                }
+            };
+
+            IList<Row> updatedRows = await smartsheet.SheetResources.RowResources.UpdateRowsAsync(1, new Row[] { rowA });
+
+            Cell updatedCell = updatedRows[0].Cells.Single(c => c.ColumnId == 101);
+            Assert.AreEqual(null, updatedCell.Hyperlink);
+            Assert.AreEqual(null, updatedCell.Value);
+        }
+
+        [TestMethod]
+        public async Task UpdateRowsAsync_ClearValue_CellLink()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Clear Value - Cell Link");
+
+            Row rowA = new Row
+            {
+                Id = 10,
+                Cells = new List<Cell>
+                {
+                    new Cell
+                    {
+                        ColumnId = 101,
+                        Value = "",
+                        LinkInFromCell = new CellLink()
+                    }
+                }
+            };
+
+            IList<Row> updatedRows = await smartsheet.SheetResources.RowResources.UpdateRowsAsync(1, new Row[] { rowA });
+
+            Cell updatedCell = updatedRows[0].Cells.Single(c => c.ColumnId == 101);
+            Assert.AreEqual(null, updatedCell.LinkInFromCell);
+            Assert.AreEqual(null, updatedCell.Value);
+        }
+
+        [TestMethod]
+        public async Task UpdateRowsAsync_ClearValue_PredecessorList()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Clear Value - Predecessor List");
+
+            Row rowA = new Row
+            {
+                Id = 10,
+                Cells = new List<Cell>
+                {
+                    new Cell
+                    {
+                        ColumnId = 123,
+                        Value = new ExplicitNull()
+                    }
+                }
+            };
+            IList<Row> updatedRows = await smartsheet.SheetResources.RowResources.UpdateRowsAsync(1, new Row[] { rowA });
+            Cell updatedCell = updatedRows[0].Cells.Single(c => c.ColumnId == 123);
+            Assert.AreEqual(updatedRows[0].Id, 10);
+            Assert.AreEqual(null, updatedCell.Value);
+        }
+
+
+        [TestMethod]
+        public async Task UpdateRowsAsync_Invalid_AssignHyperlinkAndCellLink()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Invalid - Assign Hyperlink and Cell Link");
+
+            Row rowA = new Row
+            {
+                Id = 10,
+                Cells = new List<Cell>
+                {
+                    new Cell
+                    {
+                        ColumnId = 101,
+                        Value = "",
+                        LinkInFromCell = new CellLink
+                        {
+                            ColumnId = 201,
+                            RowId = 20,
+                            SheetId = 2
+                        },
+                        Hyperlink = new Hyperlink
+                        {
+                            Url = "www.google.com"
+                        }
+                    }
+                }
+            };
+
+            await HelperFunctions.AssertRaisesExceptionAsync<SmartsheetException>(() =>
+                    smartsheet.SheetResources.RowResources.UpdateRowsAsync(1, new Row[] { rowA }),
+                "Only one of cell.hyperlink or cell.linkInFromCell may be non-null.");
+        }
+
+        [TestMethod]
+        public async Task UpdateRowsAsync_Location_Top()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Location - Top");
+
+            Row rowA = new Row
+            {
+                Id = 10,
+                ToTop = true
+            };
+
+            IList<Row> updatedRows = await smartsheet.SheetResources.RowResources.UpdateRowsAsync(1, new Row[] { rowA });
+
+            Row updateRow = updatedRows.Single(r => r.Id == 10);
+            Assert.AreEqual(1, updateRow.RowNumber);
+        }
+
+        [TestMethod]
+        public async Task UpdateRowsAsync_Location_Bottom()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Update Rows Async - Location - Bottom");
+
+            Row rowA = new Row
+            {
+                Id = 10,
+                ToBottom = true
+            };
+
+            IList<Row> updatedRows = await smartsheet.SheetResources.RowResources.UpdateRowsAsync(1, new Row[] { rowA });
+
+            Row updateRow = updatedRows.Single(r => r.Id == 10);
+            Assert.AreEqual(100, updateRow.RowNumber);
+        }
+
+        [TestMethod]
+        public async Task MoveRowAsync_AnotherSheet()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Move row to another sheet (async)");
+
+            CopyOrMoveRowResult result = await smartsheet.SheetResources.RowResources.MoveRowsToAnotherSheetAsync(
+                1228520367122308,
+                new CopyOrMoveRowDirective
+                {
+                    RowIds = new List<long>
+                    {
+                        1765250516182916
+                    },
+                    To = new CopyOrMoveRowDestination
+                    {
+                        SheetId = 799249123305348
+                    }
+                });
+            Assert.AreEqual(result.DestinationSheetId, 799249123305348);
+        }
+
+        [TestMethod]
+        public async Task CopyRowAsync_AnotherSheet()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Copy row to another sheet (async)");
+            CopyOrMoveRowResult result = await smartsheet.SheetResources.RowResources.CopyRowsToAnotherSheetAsync(
+                1228520367122308,
+                new CopyOrMoveRowDirective
+                {
+                    RowIds = new List<long>
+                    {
+                        2891150423025540
+                    },
+                    To = new CopyOrMoveRowDestination
+                    {
+                        SheetId = 799249123305348
+                    }
+                });
+            Assert.AreEqual(result.DestinationSheetId, 799249123305348);
+        }
+    }
+}

--- a/mock-api-test-sdk-net80/RowAsyncTests.cs
+++ b/mock-api-test-sdk-net80/RowAsyncTests.cs
@@ -99,7 +99,7 @@ namespace mock_api_test_sdk_net80
         [TestMethod]
         public async Task AddRowsAsync_AssignValues_Bool()
         {
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows Async - Assign Values - Bool");
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Assign Values - Bool");
 
             Row rowA = new Row
             {

--- a/mock-api-test-sdk-net80/reports/TestAddReportColumnsAsync.cs
+++ b/mock-api-test-sdk-net80/reports/TestAddReportColumnsAsync.cs
@@ -1,0 +1,138 @@
+using Newtonsoft.Json;
+using Smartsheet.Api;
+using Smartsheet.Api.Models;
+
+namespace mock_api_test_sdk_net80
+{
+    [TestClass]
+    public class TestAddReportColumnsAsync
+    {
+        private static readonly List<ReportColumn> COLUMNS_TO_ADD_REQUIRED = new List<ReportColumn>
+        {
+            new ReportColumn { Title = "Item selected", Type = ColumnType.CHECKBOX, Index = 4 },
+            new ReportColumn { Title = "Sheet name", Type = ColumnType.TEXT_NUMBER, Index = 5 }
+        };
+
+        private static readonly List<ReportColumn> COLUMNS_TO_ADD_ALL = new List<ReportColumn>
+        {
+            new ReportColumn { Title = "Item selected", Type = ColumnType.CHECKBOX, Index = 4, Hidden = false, Width = 150 },
+            new ReportColumn { Title = "Sheet name", Type = ColumnType.TEXT_NUMBER, Index = 5, Hidden = false, Width = 150, SheetNameColumn = true }
+        };
+
+        private static readonly string EXPECTED_REQUIRED_REQUEST_BODY = JsonConvert.SerializeObject(new List<Dictionary<string, object>>
+        {
+            new Dictionary<string, object> { { "type", "CHECKBOX" }, { "index", 4 }, { "title", "Item selected" } },
+            new Dictionary<string, object> { { "type", "TEXT_NUMBER" }, { "index", 5 }, { "title", "Sheet name" } }
+        });
+
+        private static readonly string EXPECTED_ALL_REQUEST_BODY = JsonConvert.SerializeObject(new List<Dictionary<string, object>>
+        {
+            new Dictionary<string, object> { { "type", "CHECKBOX" }, { "hidden", false }, { "index", 4 }, { "title", "Item selected" }, { "width", 150 } },
+            new Dictionary<string, object> { { "sheetNameColumn", true }, { "type", "TEXT_NUMBER" }, { "hidden", false }, { "index", 5 }, { "title", "Sheet name" }, { "width", 150 } }
+        });
+
+        private static readonly List<ReportColumn> EXPECTED_REQUIRED_RESPONSE = new List<ReportColumn>
+        {
+            new ReportColumn { VirtualId = 12345, Index = 4, Title = "Item selected", Type = ColumnType.CHECKBOX, Version = 0 },
+            new ReportColumn { VirtualId = 12346, Index = 5, Title = "Sheet name", Type = ColumnType.TEXT_NUMBER, SheetNameColumn = true, Version = 0 },
+            new ReportColumn { VirtualId = 12347, Index = 6, Title = "Created By", Type = ColumnType.CONTACT_LIST, SystemColumnType = SystemColumnType.CREATED_BY, Version = 0 },
+            new ReportColumn { VirtualId = 12348, Index = 7, Title = "Primary", Type = ColumnType.TEXT_NUMBER, Primary = true, Version = 0 },
+            new ReportColumn { VirtualId = 12349, Index = 8, Title = "Row Number", Type = ColumnType.TEXT_NUMBER, SystemColumnType = SystemColumnType.AUTO_NUMBER, Version = 0, AutoNumberFormat = new AutoNumberFormat { Fill = "000", Prefix = "TASK-", StartingNumber = 1, Suffix = "" } }
+        };
+
+        private static readonly List<ReportColumn> EXPECTED_ALL_RESPONSE = new List<ReportColumn>
+        {
+            new ReportColumn { VirtualId = 12345, Index = 4, Title = "Item selected", Type = ColumnType.CHECKBOX, Hidden = false, Validation = false, Version = 0, Width = 150 },
+            new ReportColumn { VirtualId = 12346, Index = 5, Title = "Sheet name", Type = ColumnType.TEXT_NUMBER, SheetNameColumn = true, Hidden = false, Validation = false, Version = 0, Width = 150 },
+            new ReportColumn { VirtualId = 12347, Index = 6, Title = "Created By", Type = ColumnType.CONTACT_LIST, SystemColumnType = SystemColumnType.CREATED_BY, Hidden = false, Validation = false, Version = 0, Width = 150 },
+            new ReportColumn { VirtualId = 12348, Index = 7, Title = "Primary", Type = ColumnType.TEXT_NUMBER, Primary = true, Hidden = false, Validation = false, Version = 0, Width = 200 },
+            new ReportColumn { VirtualId = 12349, Index = 8, Title = "Row Number", Type = ColumnType.TEXT_NUMBER, SystemColumnType = SystemColumnType.AUTO_NUMBER, Hidden = false, Validation = false, Version = 0, Width = 100, AutoNumberFormat = new AutoNumberFormat { Fill = "000", Prefix = "TASK-", StartingNumber = 1, Suffix = "" } }
+        };
+
+        [TestMethod]
+        public async Task TestAddReportColumnsAsyncEmptyColumnsError()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/add-report-columns/required-response-body-properties", requestId.ToString());
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(
+                () => smartsheet.ReportResources.AddReportColumnsAsync(CommonTestConstants.TEST_REPORT_ID, new List<ReportColumn>())
+            );
+        }
+
+        [TestMethod]
+        public async Task TestAddReportColumnsAsyncGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/add-report-columns/required-response-body-properties", requestId.ToString());
+
+            await smartsheet.ReportResources.AddReportColumnsAsync(CommonTestConstants.TEST_REPORT_ID, COLUMNS_TO_ADD_REQUIRED);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+
+            Assert.AreEqual($"/2.0/reports/{CommonTestConstants.TEST_REPORT_ID}/columns", uri.AbsolutePath);
+            Assert.AreEqual("POST", foundRequest.Method);
+            Assert.AreEqual(string.Empty, uri.Query);
+        }
+
+        [TestMethod]
+        public async Task TestAddReportColumnsAsyncRequiredResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/add-report-columns/required-response-body-properties", requestId.ToString());
+
+            IList<ReportColumn> result = await smartsheet.ReportResources.AddReportColumnsAsync(CommonTestConstants.TEST_REPORT_ID, COLUMNS_TO_ADD_REQUIRED);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.AreEqual(EXPECTED_REQUIRED_REQUEST_BODY, foundRequest.Body);
+            Assert.AreEqual(JsonConvert.SerializeObject(EXPECTED_REQUIRED_RESPONSE), JsonConvert.SerializeObject(result));
+        }
+
+        [TestMethod]
+        public async Task TestAddReportColumnsAsyncAllResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/add-report-columns/all-response-body-properties", requestId.ToString());
+
+            IList<ReportColumn> result = await smartsheet.ReportResources.AddReportColumnsAsync(CommonTestConstants.TEST_REPORT_ID, COLUMNS_TO_ADD_ALL);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.AreEqual(EXPECTED_ALL_REQUEST_BODY, foundRequest.Body);
+            Assert.AreEqual(JsonConvert.SerializeObject(EXPECTED_ALL_RESPONSE), JsonConvert.SerializeObject(result));
+        }
+
+        [TestMethod]
+        public async Task TestAddReportColumnsAsyncError500Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+
+            SmartsheetException exception = await Assert.ThrowsExceptionAsync<SmartsheetException>(() =>
+                smartsheet.ReportResources.AddReportColumnsAsync(CommonTestConstants.TEST_REPORT_ID, COLUMNS_TO_ADD_REQUIRED)
+            );
+
+            Assert.IsTrue(exception.Message.Contains("Internal Server Error"));
+        }
+
+        [TestMethod]
+        public async Task TestAddReportColumnsAsyncError400Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+
+            SmartsheetException exception = await Assert.ThrowsExceptionAsync<SmartsheetException>(() =>
+                smartsheet.ReportResources.AddReportColumnsAsync(CommonTestConstants.TEST_REPORT_ID, COLUMNS_TO_ADD_REQUIRED)
+            );
+
+            Assert.IsTrue(exception.Message.Contains("Malformed Request"));
+        }
+    }
+}

--- a/mock-api-test-sdk-net80/reports/TestAddReportScopeAsync.cs
+++ b/mock-api-test-sdk-net80/reports/TestAddReportScopeAsync.cs
@@ -1,0 +1,99 @@
+using Newtonsoft.Json;
+using Smartsheet.Api;
+using Smartsheet.Api.Models;
+
+namespace mock_api_test_sdk_net80
+{
+    [TestClass]
+    public class TestAddReportScopeAsync
+    {
+        private static readonly List<ReportScopeInclusion> SCOPES_TO_ADD = new List<ReportScopeInclusion>
+        {
+            new ReportScopeInclusion
+            {
+                AssetType = ReportAssetType.SHEET,
+                AssetId = CommonTestConstants.TEST_SHEET_ID
+            }
+        };
+
+        private static readonly string EXPECTED_REQUEST_BODY = JsonConvert.SerializeObject(new List<Dictionary<string, object>>
+        {
+            new Dictionary<string, object>
+            {
+                { "assetType", "sheet" },
+                { "assetId", CommonTestConstants.TEST_SHEET_ID }
+            }
+        });
+
+        [TestMethod]
+        public async Task TestAddReportScopeAsyncEmptyScopesError()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/add-report-scope/all-response-body-properties", requestId.ToString());
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(
+                () => smartsheet.ReportResources.AddReportScopeAsync(CommonTestConstants.TEST_REPORT_ID, new List<ReportScopeInclusion>())
+            );
+        }
+
+        [TestMethod]
+        public async Task TestAddReportScopeAsyncGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/add-report-scope/all-response-body-properties", requestId.ToString());
+
+            await smartsheet.ReportResources.AddReportScopeAsync(CommonTestConstants.TEST_REPORT_ID, SCOPES_TO_ADD);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+            string path = uri.AbsolutePath;
+
+            Assert.AreEqual($"/2.0/reports/{CommonTestConstants.TEST_REPORT_ID}/scope", path);
+            Assert.AreEqual("POST", foundRequest.Method);
+            Assert.AreEqual(string.Empty, uri.Query);
+        }
+
+        [TestMethod]
+        public async Task TestAddReportScopeAsyncAllResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/add-report-scope/all-response-body-properties", requestId.ToString());
+
+            await smartsheet.ReportResources.AddReportScopeAsync(CommonTestConstants.TEST_REPORT_ID, SCOPES_TO_ADD);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.AreEqual(EXPECTED_REQUEST_BODY, foundRequest.Body);
+        }
+
+        [TestMethod]
+        public async Task TestAddReportScopeAsyncError500Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+
+            SmartsheetException exception = await Assert.ThrowsExceptionAsync<SmartsheetException>(() =>
+                smartsheet.ReportResources.AddReportScopeAsync(CommonTestConstants.TEST_REPORT_ID, SCOPES_TO_ADD)
+            );
+
+            Assert.IsTrue(exception.Message.Contains("Internal Server Error"));
+        }
+
+        [TestMethod]
+        public async Task TestAddReportScopeAsyncError400Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+
+            SmartsheetException exception = await Assert.ThrowsExceptionAsync<SmartsheetException>(() =>
+                smartsheet.ReportResources.AddReportScopeAsync(CommonTestConstants.TEST_REPORT_ID, SCOPES_TO_ADD)
+            );
+
+            Assert.IsTrue(exception.Message.Contains("Malformed Request"));
+        }
+    }
+}

--- a/mock-api-test-sdk-net80/reports/TestCreateReportAsync.cs
+++ b/mock-api-test-sdk-net80/reports/TestCreateReportAsync.cs
@@ -1,0 +1,253 @@
+using Newtonsoft.Json;
+using Smartsheet.Api;
+using Smartsheet.Api.Models;
+
+namespace mock_api_test_sdk_net80
+{
+    [TestClass]
+    public class TestCreateReportAsync
+    {
+        private static readonly CreateReportRequest REQUEST_REQUIRED = new CreateReportRequest
+        {
+            Name = "Q2 Earnings",
+            Destination = new ReportDestination
+            {
+                DestinationId = 123456789,
+                DestinationType = ReportDestinationType.FOLDER
+            },
+            Columns = new List<ReportColumn>
+            {
+                new ReportColumn { Title = "Primary", Type = ColumnType.TEXT_NUMBER, Index = 0, Primary = true }
+            },
+            Scope = new List<ReportScopeInclusion>
+            {
+                new ReportScopeInclusion { AssetType = ReportAssetType.SHEET, AssetId = 111111111 }
+            }
+        };
+
+        private static readonly CreateReportRequest REQUEST_ALL = new CreateReportRequest
+        {
+            Name = "Q2 Earnings",
+            Destination = new ReportDestination
+            {
+                DestinationId = 123456789,
+                DestinationType = ReportDestinationType.FOLDER
+            },
+            Columns = new List<ReportColumn>
+            {
+                new ReportColumn { Title = "Primary", Type = ColumnType.TEXT_NUMBER, Index = 0, Primary = true }
+            },
+            Scope = new List<ReportScopeInclusion>
+            {
+                new ReportScopeInclusion { AssetType = ReportAssetType.SHEET, AssetId = 111111111 }
+            },
+            IsSummaryReport = false,
+            ReportDefinition = new ReportDefinition
+            {
+                Filters = new ReportFilterExpression
+                {
+                    Operator = ReportFilterOperator.AND,
+                    Criteria = new List<ReportFilterCriterion>
+                    {
+                        new ReportFilterCriterion
+                        {
+                            Column = new ReportColumnIdentifier
+                            {
+                                Type = ColumnType.TEXT_NUMBER,
+                                Title = "Status"
+                            },
+                            Operator = ReportFilterCriteriaOperator.EQUAL,
+                            Values = new List<ReportFilterValue> { new StringReportFilterValue("Complete") }
+                        }
+                    }
+                }
+            }
+        };
+
+        private static readonly string EXPECTED_REQUIRED_REQUEST_BODY = JsonConvert.SerializeObject(new Dictionary<string, object>
+        {
+            { "name", "Q2 Earnings" },
+            { "columns", new List<Dictionary<string, object>>
+                {
+                    new Dictionary<string, object>
+                    {
+                        { "type", "TEXT_NUMBER" },
+                        { "index", 0 },
+                        { "primary", true },
+                        { "title", "Primary" }
+                    }
+                }
+            },
+            { "scope", new List<Dictionary<string, object>>
+                {
+                    new Dictionary<string, object>
+                    {
+                        { "assetType", "sheet" },
+                        { "assetId", 111111111L }
+                    }
+                }
+            },
+            { "destination", new Dictionary<string, object>
+                {
+                    { "destinationId", 123456789L },
+                    { "destinationType", "folder" }
+                }
+            }
+        });
+
+        private static readonly string EXPECTED_ALL_REQUEST_BODY = JsonConvert.SerializeObject(new Dictionary<string, object>
+        {
+            { "name", "Q2 Earnings" },
+            { "columns", new List<Dictionary<string, object>>
+                {
+                    new Dictionary<string, object>
+                    {
+                        { "type", "TEXT_NUMBER" },
+                        { "index", 0 },
+                        { "primary", true },
+                        { "title", "Primary" }
+                    }
+                }
+            },
+            { "scope", new List<Dictionary<string, object>>
+                {
+                    new Dictionary<string, object>
+                    {
+                        { "assetType", "sheet" },
+                        { "assetId", 111111111L }
+                    }
+                }
+            },
+            { "reportDefinition", new Dictionary<string, object>
+                {
+                    { "filters", new Dictionary<string, object>
+                        {
+                            { "operator", "AND" },
+                            { "criteria", new List<Dictionary<string, object>>
+                                {
+                                    new Dictionary<string, object>
+                                    {
+                                        { "column", new Dictionary<string, object>
+                                            {
+                                                { "title", "Status" },
+                                                { "type", "TEXT_NUMBER" }
+                                            }
+                                        },
+                                        { "operator", "EQUAL" },
+                                        { "values", new List<string> { "Complete" } }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            { "isSummaryReport", false },
+            { "destination", new Dictionary<string, object>
+                {
+                    { "destinationId", 123456789L },
+                    { "destinationType", "folder" }
+                }
+            }
+        });
+
+        private static readonly CreateReportResult EXPECTED_REQUIRED_RESPONSE = new CreateReportResult
+        {
+            Id = 987654321L,
+            Name = "Q2 Earnings Report",
+            AccessLevel = AccessLevel.OWNER,
+            Permalink = "https://app.smartsheet.com/reports/c8gJxw87cXpRCvCC5PPw6jFhFRrf5r8PxCrxvW21"
+        };
+
+        private static readonly CreateReportResult EXPECTED_ALL_RESPONSE = new CreateReportResult
+        {
+            Id = 987654321L,
+            Name = "Q2 Earnings Report",
+            AccessLevel = AccessLevel.OWNER,
+            Permalink = "https://app.smartsheet.com/reports/c8gJxw87cXpRCvCC5PPw6jFhFRrf5r8PxCrxvW21",
+            IsSummaryReport = false,
+            Columns = new List<ReportColumn>
+            {
+                new ReportColumn { VirtualId = 1234567890123456, Index = 0, Title = "Primary column", Type = ColumnType.TEXT_NUMBER, Primary = true, Hidden = false, Version = 0, Width = 200, Validation = false },
+                new ReportColumn { VirtualId = 2345678901234567, Index = 1, Title = "Sheet name", Type = ColumnType.TEXT_NUMBER, SheetNameColumn = true, Hidden = false, Version = 0, Width = 150, Validation = false },
+                new ReportColumn { VirtualId = 3456789012345678, Index = 2, Title = "Created at", Type = ColumnType.DATETIME, SystemColumnType = SystemColumnType.CREATED_DATE, Hidden = false, Version = 0, Width = 150, Validation = false },
+                new ReportColumn { VirtualId = 4567890123456789, Index = 3, Title = "Selected item", Type = ColumnType.PICKLIST, Hidden = false, Version = 0, Width = 150, Validation = false }
+            }
+        };
+
+        [TestMethod]
+        public async Task TestCreateReportAsyncGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/create-report/required-response-body-properties", requestId.ToString());
+
+            await smartsheet.ReportResources.CreateReportAsync(REQUEST_REQUIRED);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+
+            Assert.AreEqual("/2.0/reports", uri.AbsolutePath);
+            Assert.AreEqual("POST", foundRequest.Method);
+            Assert.AreEqual(string.Empty, uri.Query);
+        }
+
+        [TestMethod]
+        public async Task TestCreateReportAsyncRequiredResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/create-report/required-response-body-properties", requestId.ToString());
+
+            CreateReportResult result = await smartsheet.ReportResources.CreateReportAsync(REQUEST_REQUIRED);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.AreEqual(EXPECTED_REQUIRED_REQUEST_BODY, foundRequest.Body);
+            Assert.AreEqual(JsonConvert.SerializeObject(EXPECTED_REQUIRED_RESPONSE), JsonConvert.SerializeObject(result));
+        }
+
+        [TestMethod]
+        public async Task TestCreateReportAsyncAllResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/create-report/all-response-body-properties", requestId.ToString());
+
+            CreateReportResult result = await smartsheet.ReportResources.CreateReportAsync(REQUEST_ALL);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.AreEqual(EXPECTED_ALL_REQUEST_BODY, foundRequest.Body);
+            Assert.AreEqual(JsonConvert.SerializeObject(EXPECTED_ALL_RESPONSE), JsonConvert.SerializeObject(result));
+        }
+
+        [TestMethod]
+        public async Task TestCreateReportAsyncError500Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+
+            SmartsheetException exception = await Assert.ThrowsExceptionAsync<SmartsheetException>(() =>
+                smartsheet.ReportResources.CreateReportAsync(REQUEST_REQUIRED)
+            );
+
+            Assert.IsTrue(exception.Message.Contains("Internal Server Error"));
+        }
+
+        [TestMethod]
+        public async Task TestCreateReportAsyncError400Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+
+            SmartsheetException exception = await Assert.ThrowsExceptionAsync<SmartsheetException>(() =>
+                smartsheet.ReportResources.CreateReportAsync(REQUEST_REQUIRED)
+            );
+
+            Assert.IsTrue(exception.Message.Contains("Malformed Request"));
+        }
+    }
+}

--- a/mock-api-test-sdk-net80/reports/TestDeleteReportAsync.cs
+++ b/mock-api-test-sdk-net80/reports/TestDeleteReportAsync.cs
@@ -1,0 +1,60 @@
+using Smartsheet.Api;
+
+namespace mock_api_test_sdk_net80
+{
+    [TestClass]
+    public class TestDeleteReportAsync
+    {
+        [TestMethod]
+        public async Task TestDeleteReportAsyncGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient ss = HelperFunctions.SetupClient("/reports/delete-report/all-response-body-properties", requestId.ToString());
+
+            await ss.ReportResources.DeleteReportAsync(CommonTestConstants.TEST_REPORT_ID);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+            Assert.IsNotNull(foundRequest);
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+
+            Assert.AreEqual(string.Format("/2.0/reports/{0}", CommonTestConstants.TEST_REPORT_ID), uri.AbsolutePath);
+            Assert.AreEqual("DELETE", foundRequest.Method);
+            Assert.AreEqual(string.Empty, uri.Query);
+        }
+
+        [TestMethod]
+        public async Task TestDeleteReportAsyncAllResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient ss = HelperFunctions.SetupClient("/reports/delete-report/all-response-body-properties", requestId.ToString());
+
+            await ss.ReportResources.DeleteReportAsync(CommonTestConstants.TEST_REPORT_ID);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+            Assert.AreEqual(string.Empty, foundRequest.Body);
+        }
+
+        [TestMethod]
+        public async Task TestDeleteReportAsyncError400Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+
+            SmartsheetException exception = await Assert.ThrowsExceptionAsync<SmartsheetException>(() => ss.ReportResources.DeleteReportAsync(CommonTestConstants.TEST_REPORT_ID));
+            Assert.IsTrue(exception.Message.Contains("Malformed Request"));
+        }
+
+        [TestMethod]
+        public async Task TestDeleteReportAsyncError500Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient ss = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+
+            SmartsheetException exception = await Assert.ThrowsExceptionAsync<SmartsheetException>(() => ss.ReportResources.DeleteReportAsync(CommonTestConstants.TEST_REPORT_ID));
+            Assert.IsTrue(exception.Message.Contains("Internal Server Error"));
+        }
+    }
+}

--- a/mock-api-test-sdk-net80/reports/TestRemoveReportScopeAsync.cs
+++ b/mock-api-test-sdk-net80/reports/TestRemoveReportScopeAsync.cs
@@ -1,0 +1,98 @@
+using Newtonsoft.Json;
+using Smartsheet.Api;
+using Smartsheet.Api.Models;
+
+namespace mock_api_test_sdk_net80
+{
+    [TestClass]
+    public class TestRemoveReportScopeAsync
+    {
+        private static readonly List<ReportScopeInclusion> SCOPES_TO_REMOVE = new List<ReportScopeInclusion>
+        {
+            new ReportScopeInclusion
+            {
+                AssetType = ReportAssetType.SHEET,
+                AssetId = CommonTestConstants.TEST_SHEET_ID
+            }
+        };
+
+        private static readonly string EXPECTED_REQUEST_BODY = JsonConvert.SerializeObject(new List<Dictionary<string, object>>
+        {
+            new Dictionary<string, object>
+            {
+                { "assetType", "sheet" },
+                { "assetId", CommonTestConstants.TEST_SHEET_ID }
+            }
+        });
+
+        [TestMethod]
+        public async Task TestRemoveReportScopeAsyncEmptyScopesError()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/remove-report-scope/all-response-body-properties", requestId.ToString());
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(
+                () => smartsheet.ReportResources.RemoveReportScopeAsync(CommonTestConstants.TEST_REPORT_ID, new List<ReportScopeInclusion>())
+            );
+        }
+
+        [TestMethod]
+        public async Task TestRemoveReportScopeAsyncGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/remove-report-scope/all-response-body-properties", requestId.ToString());
+
+            await smartsheet.ReportResources.RemoveReportScopeAsync(CommonTestConstants.TEST_REPORT_ID, SCOPES_TO_REMOVE);
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+            string path = uri.AbsolutePath;
+
+            Assert.AreEqual($"/2.0/reports/{CommonTestConstants.TEST_REPORT_ID}/scope", path);
+            Assert.AreEqual("DELETE", foundRequest.Method);
+            Assert.AreEqual(string.Empty, uri.Query);
+        }
+
+        [TestMethod]
+        public async Task TestRemoveReportScopeAsyncAllResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/remove-report-scope/all-response-body-properties", requestId.ToString());
+
+            await smartsheet.ReportResources.RemoveReportScopeAsync(CommonTestConstants.TEST_REPORT_ID, SCOPES_TO_REMOVE);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.AreEqual(EXPECTED_REQUEST_BODY, foundRequest.Body);
+        }
+
+        [TestMethod]
+        public async Task TestRemoveReportScopeAsyncError500Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+
+            SmartsheetException exception = await Assert.ThrowsExceptionAsync<SmartsheetException>(() =>
+                smartsheet.ReportResources.RemoveReportScopeAsync(CommonTestConstants.TEST_REPORT_ID, SCOPES_TO_REMOVE)
+            );
+
+            Assert.IsTrue(exception.Message.Contains("Internal Server Error"));
+        }
+
+        [TestMethod]
+        public async Task TestRemoveReportScopeAsyncError400Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+
+            SmartsheetException exception = await Assert.ThrowsExceptionAsync<SmartsheetException>(() =>
+                smartsheet.ReportResources.RemoveReportScopeAsync(CommonTestConstants.TEST_REPORT_ID, SCOPES_TO_REMOVE)
+            );
+
+            Assert.IsTrue(exception.Message.Contains("Malformed Request"));
+        }
+    }
+}

--- a/mock-api-test-sdk-net80/reports/TestUpdateReportDefinitionAsync.cs
+++ b/mock-api-test-sdk-net80/reports/TestUpdateReportDefinitionAsync.cs
@@ -1,0 +1,367 @@
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Smartsheet.Api;
+using Smartsheet.Api.Models;
+
+namespace mock_api_test_sdk_net80
+{
+    [TestClass]
+    public class TestUpdateReportDefinitionAsync
+    {
+        private static readonly ReportDefinition DEFINITION_ALL = new ReportDefinition
+        {
+            SummarizingCriteria = new List<ReportSummarizingCriterion>
+            {
+                new ReportSummarizingCriterion
+                {
+                    AggregationType = ReportAggregationType.COUNT,
+                    Column = new ReportColumnIdentifier
+                    {
+                        Primary = true,
+                        Type = ColumnType.TEXT_NUMBER,
+                        SystemColumnType = SystemColumnType.AUTO_NUMBER,
+                        Title = "Primary Column",
+                    }
+                }
+            },
+            Filters = new ReportFilterExpression
+            {
+                Operator = ReportFilterOperator.AND,
+                Criteria = new List<ReportFilterCriterion>
+                {
+                    new ReportFilterCriterion
+                    {
+                        Column = new ReportColumnIdentifier
+                        {
+                            Primary = true,
+                            Type = ColumnType.TEXT_NUMBER,
+                            SystemColumnType = SystemColumnType.AUTO_NUMBER,
+                            Title = "Primary Column",
+                        },
+                        Operator = ReportFilterCriteriaOperator.EQUAL,
+                        Values = new List<ReportFilterValue> { new StringReportFilterValue("Test") },
+                    }
+                }
+            },
+            GroupingCriteria = new List<ReportGroupingCriterion>
+            {
+                new ReportGroupingCriterion
+                {
+                    Column = new ReportColumnIdentifier
+                    {
+                        Primary = true,
+                        Type = ColumnType.TEXT_NUMBER,
+                        SystemColumnType = SystemColumnType.AUTO_NUMBER,
+                        Title = "Primary Column",
+                    },
+                    SortingDirection = SortDirection.ASCENDING,
+                    IsExpanded = true
+                }
+            },
+            SortingCriteria = new List<ReportSortingCriterion>
+            {
+                new ReportSortingCriterion
+                {
+                    Column = new ReportColumnIdentifier
+                    {
+                        Primary = true,
+                        Type = ColumnType.TEXT_NUMBER,
+                        SystemColumnType = SystemColumnType.AUTO_NUMBER,
+                        Title = "Primary Column",
+                    },
+                    SortingDirection = SortDirection.ASCENDING
+                }
+            },
+        };
+
+        private static readonly string EXPECTED_ALL_REQUEST_BODY = JsonConvert.SerializeObject(new Dictionary<string, object>
+        {
+            { "filters", new Dictionary<string, object>
+                    {
+                        { "operator", "AND" },
+                        { "criteria", new List<Dictionary<string, object>>
+                            {
+                                new Dictionary<string, object>
+                                {
+                                    { "column", new Dictionary<string, object>
+                                        {
+                                            { "title", "Primary Column" },
+                                            { "type", "TEXT_NUMBER" },
+                                            { "systemColumnType", "AUTO_NUMBER" },
+                                            { "primary", true },
+                                        }
+                                    },
+                                    { "operator", "EQUAL" },
+                                    { "values", new List<string> { "Test" } }
+                                }
+                            }
+                        }
+                    }
+            },
+            { "groupingCriteria", new List<Dictionary<string, object>>
+                {
+                    new Dictionary<string, object>
+                    {
+                        { "column", new Dictionary<string, object>
+                            {
+                                { "title", "Primary Column" },
+                                { "type", "TEXT_NUMBER" },
+                                { "systemColumnType", "AUTO_NUMBER" },
+                                { "primary", true },
+                            }
+                        },
+                        { "sortingDirection", "ASCENDING" },
+                        { "isExpanded", true }
+                    }
+                }
+            },
+            { "summarizingCriteria", new List<Dictionary<string, object>>
+                {
+                    new Dictionary<string, object>
+                    {
+                        { "column", new Dictionary<string, object>
+                            {
+                                { "title", "Primary Column" },
+                                { "type", "TEXT_NUMBER" },
+                                { "systemColumnType", "AUTO_NUMBER" },
+                                { "primary", true },
+                            }
+                        },
+                        { "aggregationType", "COUNT" }
+                    }
+                }
+            },
+            { "sortingCriteria", new List<Dictionary<string, object>>
+                {
+                    new Dictionary<string, object>
+                    {
+                        { "column", new Dictionary<string, object>
+                            {
+                                { "title", "Primary Column" },
+                                { "type", "TEXT_NUMBER" },
+                                { "systemColumnType", "AUTO_NUMBER" },
+                                { "primary", true },
+                            }
+                        },
+                        { "sortingDirection", "ASCENDING" },
+                    }
+                }
+            },
+        });
+
+        [TestMethod]
+        public async Task TestUpdateReportDefinitionAsyncGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/update-report-definition/all-response-body-properties", requestId.ToString());
+
+
+            await smartsheet.ReportResources.UpdateReportDefinitionAsync(CommonTestConstants.TEST_REPORT_ID, new ReportDefinition());
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+            string path = uri.AbsolutePath;
+
+            Assert.AreEqual($"/2.0/reports/{CommonTestConstants.TEST_REPORT_ID}/definition", path);
+            Assert.AreEqual("PUT", foundRequest.Method);
+            Assert.AreEqual(string.Empty, uri.Query);
+        }
+
+        [TestMethod]
+        public async Task TestUpdateReportDefinitionAsyncAllResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/update-report-definition/all-response-body-properties", requestId.ToString());
+
+            await smartsheet.ReportResources.UpdateReportDefinitionAsync(CommonTestConstants.TEST_REPORT_ID, DEFINITION_ALL);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.AreEqual(EXPECTED_ALL_REQUEST_BODY, foundRequest.Body);
+        }
+
+        [TestMethod]
+        public async Task TestUpdateReportDefinitionAsyncEmptyBody()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/update-report-definition/all-response-body-properties", requestId.ToString());
+
+            await smartsheet.ReportResources.UpdateReportDefinitionAsync(CommonTestConstants.TEST_REPORT_ID, new ReportDefinition());
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            var expectedBody = JsonConvert.SerializeObject(new Dictionary<string, object>());
+
+            Assert.AreEqual(expectedBody, foundRequest.Body);
+        }
+
+
+        [TestMethod]
+        public async Task TestUpdateReportDefinitionAsyncFiltersOnlyRequestBody()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/update-report-definition/all-response-body-properties", requestId.ToString());
+
+            ReportDefinition definition = new ReportDefinition
+            {
+                Filters = new ReportFilterExpression
+                {
+                    Operator = ReportFilterOperator.AND,
+                    Criteria = new List<ReportFilterCriterion>
+                    {
+                        new ReportFilterCriterion
+                        {
+                            Column = new ReportColumnIdentifier
+                            {
+                                Primary = true,
+                                Type = ColumnType.TEXT_NUMBER,
+                                Title = "Primary Column",
+                            },
+                            Operator = ReportFilterCriteriaOperator.EQUAL,
+                            Values = new List<ReportFilterValue> { new StringReportFilterValue("Test") },
+                        }
+                    }
+                }
+            };
+
+            await smartsheet.ReportResources.UpdateReportDefinitionAsync(CommonTestConstants.TEST_REPORT_ID, definition);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            var expectedBody = JsonConvert.SerializeObject(new Dictionary<string, object>
+            {
+                { "filters", new Dictionary<string, object>
+                        {
+                            { "operator", "AND" },
+                            { "criteria", new List<Dictionary<string, object>>
+                                {
+                                    new Dictionary<string, object>
+                                    {
+                                        { "column", new Dictionary<string, object>
+                                            {
+                                                { "title", "Primary Column" },
+                                                { "type", "TEXT_NUMBER" },
+                                                { "primary", true },
+                                            }
+                                        },
+                                        { "operator", "EQUAL" },
+                                        { "values", new List<string> { "Test" } }
+                                    }
+                                }
+                            }
+                        }
+                }
+            });
+
+            Assert.AreEqual(expectedBody, foundRequest.Body);
+        }
+
+        [TestMethod]
+        public async Task TestUpdateReportDefinitionAsyncError500Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+
+            SmartsheetException exception = await Assert.ThrowsExceptionAsync<SmartsheetException>(() =>
+                smartsheet.ReportResources.UpdateReportDefinitionAsync(CommonTestConstants.TEST_REPORT_ID, new ReportDefinition())
+            );
+
+            Assert.IsTrue(exception.Message.Contains("Internal Server Error"));
+        }
+
+        [TestMethod]
+        public async Task TestUpdateReportDefinitionAsyncError400Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+
+            SmartsheetException exception = await Assert.ThrowsExceptionAsync<SmartsheetException>(() =>
+                smartsheet.ReportResources.UpdateReportDefinitionAsync(CommonTestConstants.TEST_REPORT_ID, new ReportDefinition())
+            );
+
+            Assert.IsTrue(exception.Message.Contains("Malformed Request"));
+        }
+
+        [TestMethod]
+        public async Task TestUpdateReportDefinitionAsyncWithAllFilterValueTypes()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/update-report-definition/all-response-body-properties", requestId.ToString());
+
+            ReportDefinition definition = new ReportDefinition
+            {
+                Filters = new ReportFilterExpression
+                {
+                    Operator = ReportFilterOperator.AND,
+                    Criteria = new List<ReportFilterCriterion>
+                    {
+                        new ReportFilterCriterion
+                        {
+                            Column = new ReportColumnIdentifier
+                            {
+                                Primary = true,
+                                Type = ColumnType.TEXT_NUMBER,
+                                Title = "Primary Column",
+                            },
+                            Operator = ReportFilterCriteriaOperator.EQUAL,
+                            Values = new List<ReportFilterValue>
+                            {
+                                new StringReportFilterValue("Test String"),
+                                new NumberReportFilterValue(42.5),
+                                new NullReportFilterValue(),
+                                new DateReportFilterValue("2024-01-15"),
+                                new CurrentUserReportFilterValue()
+                            },
+                        }
+                    }
+                }
+            };
+
+            await smartsheet.ReportResources.UpdateReportDefinitionAsync(CommonTestConstants.TEST_REPORT_ID, definition);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            var expectedBody = JsonConvert.SerializeObject(new Dictionary<string, object>
+            {
+                { "filters", new Dictionary<string, object>
+                    {
+                        { "operator", "AND" },
+                        { "criteria", new List<Dictionary<string, object>>
+                            {
+                                new Dictionary<string, object>
+                                {
+                                    { "column", new Dictionary<string, object>
+                                        {
+                                            { "title", "Primary Column" },
+                                            { "type", "TEXT_NUMBER" },
+                                            { "primary", true },
+                                        }
+                                    },
+                                    { "operator", "EQUAL" },
+                                    { "values", new List<object>
+                                        {
+                                            "Test String",
+                                            42.5,
+                                            null,
+                                            new Dictionary<string, object> { { "objectType", "DATE" }, { "value", "2024-01-15" } },
+                                            new Dictionary<string, object> { { "objectType", "CURRENT_USER" } }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+
+            Assert.AreEqual(expectedBody, foundRequest.Body);
+        }
+    }
+}

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
@@ -964,7 +964,7 @@ namespace Smartsheet.Api.Internal
         }
 
         /// <summary>
-        /// Post an object to SmartsheetClient REST API and receive a list of objects from response.
+        /// Asynchronously post an object to SmartsheetClient REST API and receive a list of objects from response.
         /// 
         /// Parameters: - path : the relative path of the resource collections - objectToPost : the object to post -
         /// objectClassToReceive : the resource object class to receive
@@ -1042,7 +1042,7 @@ namespace Smartsheet.Api.Internal
         }
 
         /// <summary>
-        /// Put an object to SmartsheetClient REST API and receive a list of objects from response.
+        /// Asynchronously put an object to SmartsheetClient REST API and receive a list of objects from response.
         /// 
         /// Exceptions:
         ///   IllegalArgumentException : if any argument is null, or path is an empty string

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
@@ -960,6 +960,33 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
         protected internal virtual IList<S> PostAndReceiveList<T, S>(string path, T objectToPost, Type objectClassToReceive)
         {
+            return this.PostAndReceiveListAsync<T, S>(path, objectToPost, objectClassToReceive).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Post an object to SmartsheetClient REST API and receive a list of objects from response.
+        /// 
+        /// Parameters: - path : the relative path of the resource collections - objectToPost : the object to post -
+        /// objectClassToReceive : the resource object class to receive
+        /// 
+        /// Returns: the object list
+        /// 
+        /// Exceptions:
+        ///   IllegalArgumentException : if any argument is null, or path is an empty string
+        ///   InvalidRequestException : if there is any problem with the REST API request
+        ///   AuthorizationException : if there is any problem with the REST API authorization (access token)
+        ///   ServiceUnavailableException : if the REST API service is not available (possibly due to rate limiting)
+        ///   SmartsheetRestException : if any other REST API related error occurred during the operation
+        ///   SmartsheetException : if any other error occurred during the operation
+        /// </summary>
+        /// <param name="path"> the path </param>
+        /// <param name="objectToPost"> the object to post </param>
+        /// <param name="objectClassToReceive"> the object class to receive </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the list </returns>
+        /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
+        protected async internal virtual Task<IList<S>> PostAndReceiveListAsync<T, S>(string path, T objectToPost, Type objectClassToReceive, CancellationToken cancellationToken = default)
+        {
             Utils.ThrowIfNull(path, objectToPost, objectClassToReceive);
             Utils.ThrowIfEmpty(path);
 
@@ -975,7 +1002,7 @@ namespace Smartsheet.Api.Internal
 
             request.Entity = serializeToEntity<T>(objectToPost);
 
-            HttpResponse response = this.smartsheet.HttpClient.Request(request);
+            HttpResponse response = await this.smartsheet.HttpClient.RequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             IList<S> obj = null;
             switch (response.StatusCode)
@@ -1011,6 +1038,28 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
         protected internal virtual IList<S> PutAndReceiveList<T, S>(string path, T objectToPut, Type objectClassToReceive)
         {
+            return this.PutAndReceiveListAsync<T, S>(path, objectToPut, objectClassToReceive).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Put an object to SmartsheetClient REST API and receive a list of objects from response.
+        /// 
+        /// Exceptions:
+        ///   IllegalArgumentException : if any argument is null, or path is an empty string
+        ///   InvalidRequestException : if there is any problem with the REST API request
+        ///   AuthorizationException : if there is any problem with the REST API authorization (access token)
+        ///   ServiceUnavailableException : if the REST API service is not available (possibly due to rate limiting)
+        ///   SmartsheetRestException : if any other REST API related error occurred during the operation
+        ///   SmartsheetException : if any other error occurred during the operation
+        /// </summary>
+        /// <param name="path"> the relative path of the resource collections </param>
+        /// <param name="objectToPut"> the object to put </param>
+        /// <param name="objectClassToReceive"> the resource object class to receive </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the object list </returns>
+        /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
+        protected internal virtual async Task<IList<S>> PutAndReceiveListAsync<T, S>(string path, T objectToPut, Type objectClassToReceive, CancellationToken cancellationToken = default)
+        {
             Utils.ThrowIfNull(path, objectToPut, objectClassToReceive);
             Utils.ThrowIfEmpty(path);
 
@@ -1026,7 +1075,7 @@ namespace Smartsheet.Api.Internal
 
             request.Entity = serializeToEntity<T>(objectToPut);
 
-            HttpResponse response = this.smartsheet.HttpClient.Request(request);
+            HttpResponse response = await this.smartsheet.HttpClient.RequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             IList<S> obj = null;
             switch (response.StatusCode)

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/ReportResourcesImpl.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/ReportResourcesImpl.cs
@@ -24,6 +24,8 @@ using Smartsheet.Api.Internal.Http;
 using System.Net;
 using Utils = Smartsheet.Api.Internal.Utility.Utility;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Smartsheet.Api.Internal
 {
@@ -65,7 +67,7 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual Report GetReport(long reportId, IEnumerable<ReportInclusion>? includes, int? pageSize, int? page)
         {
-            return GetReport(reportId, includes, pageSize, page, null);
+            return this.GetReportAsync(reportId, includes, pageSize, page).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -90,6 +92,57 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual Report GetReport(long reportId, IEnumerable<ReportInclusion>? includes, int? pageSize, int? page, int? level)
         {
+            return this.GetReportAsync(reportId, includes, pageSize, page, level).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Asynchronously sets the Report, including one page of Rows, and optionally populated with Discussions, Attachments, and source Sheets.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{reportId}</para>
+        /// </summary>
+        /// <remarks>This method returns the top 100 rows. To get more or less rows please use the other overloaded versions of this method</remarks>
+        /// <param name="reportId"> the Id of the report </param>
+        /// <param name="includes"> used to specify the optional objects to include. </param>
+        /// <param name="pageSize">(optional): Number of rows per page. If not specified, the default value is 100.
+        /// This operation can return a maximum of 500 rows per page.</param>
+        /// <param name="page">(optional): Which page number (1-based) to return. 
+        /// If not specified, the default value is 1. If a page number is specified that is greater than the number of total pages, the last page will be returned.</param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the report resource (note that if there is no such resource, this method will throw 
+        /// ResourceNotFoundException rather than returning null). </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public virtual Task<Report> GetReportAsync(long reportId, IEnumerable<ReportInclusion>? includes, int? pageSize, int? page, CancellationToken cancellationToken = default)
+        {
+            return this.GetReportAsync(reportId, includes, pageSize, page, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// <para>Asynchronously gets the Report, including one page of Rows, and optionally populated with Discussions, Attachments, and source Sheets.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{reportId}</para>
+        /// </summary>
+        /// <remarks>This method returns the top 100 rows. To get more or less rows please use the other overloaded versions of this method</remarks>
+        /// <param name="reportId"> the Id of the report </param>
+        /// <param name="includes"> used to specify the optional objects to include. </param>
+        /// <param name="pageSize">(optional): Number of rows per page. If not specified, the default value is 100.
+        /// This operation can return a maximum of 500 rows per page.</param>
+        /// <param name="page">(optional): Which page number (1-based) to return. 
+        /// If not specified, the default value is 1. If a page number is specified that is greater than the number of total pages, the last page will be returned.</param>
+        /// <param name="level"> compatibility level </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the report resource (note that if there is no such resource, this method will throw 
+        /// ResourceNotFoundException rather than returning null). </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task<Report> GetReportAsync(long reportId, IEnumerable<ReportInclusion>? includes, int? pageSize, int? page, int? level, CancellationToken cancellationToken = default)
+        {
             IDictionary<string, string> parameters = new Dictionary<string, string>();
             if (includes != null)
             {
@@ -108,7 +161,8 @@ namespace Smartsheet.Api.Internal
                 parameters.Add("level", level.ToString());
             }
 
-            return this.GetResource<Report>(QueryUtil.GenerateUrl("reports/" + reportId, parameters), typeof(Report));
+            Report report = await this.GetResourceAsync<Report>(QueryUtil.GenerateUrl("reports/" + reportId, parameters), typeof(Report), cancellationToken).ConfigureAwait(false);
+            return report;
         }
 
         /// <summary>
@@ -132,6 +186,31 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual PaginatedResult<Report> ListReports(PaginationParameters? paging, DateTime? modifiedSince)
         {
+            return this.ListReportsAsync(paging, modifiedSince).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Asynchronously gets the list of all Reports that the User has access to, in alphabetical order, by name.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /reports</para>
+        /// </summary>
+        /// <param name="paging">the pagination</param>
+        /// <param name="modifiedSince">restrict results to reports modified on or after the specified date</param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns>A list of Report objects limited to the following attributes:
+        /// <list type="bullet">
+        /// <item><description>id</description></item>
+        /// <item><description>name</description></item>
+        /// <item><description>accessLevel</description></item>
+        /// <item><description>permalink</description></item>
+        /// </list></returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task<PaginatedResult<Report>> ListReportsAsync(PaginationParameters? paging, DateTime? modifiedSince, CancellationToken cancellationToken = default)
+        {
             IDictionary<string, string> parameters = new Dictionary<string, string>();
             if (paging != null)
             {
@@ -142,7 +221,8 @@ namespace Smartsheet.Api.Internal
                 parameters.Add("modifiedSince", ((DateTime)modifiedSince).ToUniversalTime().ToString("o"));
             }
 
-            return this.ListResourcesWithWrapper<Report>("reports" + QueryUtil.GenerateUrl(null, parameters));
+            PaginatedResult<Report> paginatedReports = await this.ListResourcesWithWrapperAsync<Report>("reports" + QueryUtil.GenerateUrl(null, parameters), cancellationToken).ConfigureAwait(false);
+            return paginatedReports;
         }
 
         /// <summary>
@@ -197,7 +277,26 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual void SendReport(long reportId, SheetEmail email)
         {
-            this.CreateResource<SheetEmail>("reports/" + reportId + "/emails", typeof(SheetEmail), email);
+            this.SendReportAsync(reportId, email).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Asynchronously send a report as a PDF attachment via Email to the designated recipients.</para>
+        /// 
+        /// <para>It mirrors to the following Smartsheet REST API method: POST /reports/{reportId}/emails</para>
+        /// </summary>
+        /// <param name="reportId"> the reportId </param>
+        /// <param name="email"> the Email </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task SendReportAsync(long reportId, SheetEmail email, CancellationToken cancellationToken = default)
+        {
+            await this.CreateResourceAsync<SheetEmail>("reports/" + reportId + "/emails", typeof(SheetEmail), email, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -214,7 +313,25 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual void DeleteReport(long reportId)
         {
-            this.DeleteResource<Report>("reports/" + reportId, typeof(Report));
+            this.DeleteReportAsync(reportId).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Asynchronously deletes a report.</para>
+        /// 
+        /// <para>Mirrors the following Smartsheet REST API method: DELETE /reports/{reportId}</para>
+        /// </summary>
+        /// <param name="reportId"> the report Id </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task DeleteReportAsync(long reportId, CancellationToken cancellationToken = default)
+        {
+            await this.DeleteResourceAsync<Report>("reports/" + reportId, typeof(Report), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -235,7 +352,30 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public ReportPublish GetPublishStatus(long reportId)
         {
-            return this.GetResource<ReportPublish>("reports/" + reportId + "/publish", typeof(ReportPublish));
+            return this.GetPublishStatusAsync(reportId).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Asynchronously get the publish status of a report.</para>
+        /// 
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{id}/publish</para>
+        /// </summary>
+        /// <param name="reportId"> the reportId </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns>
+        /// The report publish status (note that if there is no such resource, this method will 
+        /// throw ResourceNotFoundException rather than returning null).
+        /// </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async Task<ReportPublish> GetPublishStatusAsync(long reportId, CancellationToken cancellationToken = default)
+        {
+            ReportPublish reportPublish = await this.GetResourceAsync<ReportPublish>("reports/" + reportId + "/publish", typeof(ReportPublish), cancellationToken).ConfigureAwait(false);
+            return reportPublish;
         }
 
         /// <summary>
@@ -259,7 +399,33 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public ReportPublish UpdatePublishStatus(long reportId, ReportPublish reportPublish)
         {
-            return this.UpdateResource<ReportPublish>("reports/" + reportId + "/publish", typeof(ReportPublish), reportPublish);
+            return this.UpdatePublishStatusAsync(reportId, reportPublish).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>
+        /// Asynchronously sets the publish status of a report and returns the new status, including the URLs of any enabled publishing.
+        /// </para>
+        /// 
+        /// <para>It mirrors to the following Smartsheet REST API method: PUT /reports/{id}/publish</para>
+        /// </summary>
+        /// <param name="reportId"> the reportId </param>
+        /// <param name="reportPublish"> the ReportPublish object</param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns>
+        /// The report publish status (note that if there is no such resource, this method will 
+        /// throw ResourceNotFoundException rather than returning null).
+        /// </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async Task<ReportPublish> UpdatePublishStatusAsync(long reportId, ReportPublish reportPublish, CancellationToken cancellationToken = default)
+        {
+            ReportPublish newReportPublish = await this.UpdateResourceAsync<ReportPublish>("reports/" + reportId + "/publish", typeof(ReportPublish), reportPublish, cancellationToken).ConfigureAwait(false);
+            return newReportPublish;
         }
 
         /// <summary>
@@ -319,6 +485,21 @@ namespace Smartsheet.Api.Internal
         /// <param name="reportDefinition"> the ReportDefinition object </param>
         public void UpdateReportDefinition(long reportId, ReportDefinition reportDefinition)
         {
+            this.UpdateReportDefinitionAsync(reportId, reportDefinition).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Asynchronously update a Report's definition based on the specified ID
+        /// <para>Note:</para>
+        /// <para>This endpoint supports partial updates <b>only on root level</b> properties of the report definition, such as <c>filters</c>, <c>groupingCriteria</c> and <c>summarizingCriteria</c>. For example, you can update the report's filters without affecting its grouping criteria. However, nested properties within these objects, such as a specific filter or grouping criterion, cannot be updated individually and require a full replacement of the respective section.</para>
+        /// 
+        /// <para>It mirrors to the following Smartsheet REST API method: PUT /reports/{reportId}/definition</para>
+        /// </summary>
+        /// <param name="reportId"> the reportId </param>
+        /// <param name="reportDefinition"> the ReportDefinition object </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        public async Task UpdateReportDefinitionAsync(long reportId, ReportDefinition reportDefinition, CancellationToken cancellationToken = default)
+        {
             string path = "reports/" + reportId + "/definition";
 
             HttpRequest request;
@@ -333,7 +514,7 @@ namespace Smartsheet.Api.Internal
 
             request.Entity = serializeToEntity(reportDefinition);
 
-            HttpResponse response = smartsheet.HttpClient.Request(request);
+            HttpResponse response = await smartsheet.HttpClient.RequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             switch (response.StatusCode)
             {
@@ -363,6 +544,26 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public void AddReportScope(long reportId, IEnumerable<ReportScopeInclusion> scopes)
         {
+            this.AddReportScopeAsync(reportId, scopes).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>
+        /// Asynchronously adds one or more specified sheet or workspace to the report scope.
+        /// </para>
+        /// </summary>
+        /// <param name="reportId"> the reportId </param>
+        /// <param name="scopes"> an array of one or more objects denoting the sheets or workspaces associated with the report </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <exception cref="InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="ArgumentException"> if scopes are empty </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async Task AddReportScopeAsync(long reportId, IEnumerable<ReportScopeInclusion> scopes, CancellationToken cancellationToken = default)
+        {
             string path = "reports/" + reportId + "/scope";
 
             Utils.ThrowIfNull(scopes);
@@ -383,7 +584,7 @@ namespace Smartsheet.Api.Internal
 
             request.Entity = serializeToEntity(scopes);
 
-            HttpResponse response = smartsheet.HttpClient.Request(request);
+            HttpResponse response = await smartsheet.HttpClient.RequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             switch (response.StatusCode)
             {
@@ -413,6 +614,26 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public void RemoveReportScope(long reportId, IEnumerable<ReportScopeInclusion> scopes)
         {
+            this.RemoveReportScopeAsync(reportId, scopes).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>
+        /// Asynchronously removes one or more specified sheet or workspace from the report scope.
+        /// </para>
+        /// </summary>
+        /// <param name="reportId"> the reportId </param>
+        /// <param name="scopes"> an array of one or more objects denoting the sheets or workspaces associated with the report </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <exception cref="InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="ArgumentException"> if scopes are empty </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async Task RemoveReportScopeAsync(long reportId, IEnumerable<ReportScopeInclusion> scopes, CancellationToken cancellationToken = default)
+        {
             string path = "reports/" + reportId + "/scope";
 
             Utils.ThrowIfNull(scopes);
@@ -433,7 +654,7 @@ namespace Smartsheet.Api.Internal
 
             request.Entity = serializeToEntity(scopes);
 
-            HttpResponse response = smartsheet.HttpClient.Request(request);
+            HttpResponse response = await smartsheet.HttpClient.RequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             switch (response.StatusCode)
             {
@@ -479,6 +700,38 @@ namespace Smartsheet.Api.Internal
 
         /// <summary>
         /// <para>
+        /// Asynchronously add columns to a report specified by a report ID. Note: all indexes of the columns must be equal.
+        /// </para>
+        /// <para>It mirrors to the following Smartsheet REST API method: POST /reports/{reportId}/columns</para>
+        /// </summary>
+        /// <param name="reportId"> the reportId </param>
+        /// <param name="reportColumns"> list of report columns to be added (minItems: 1, maxItems: 400) </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> list of report columns that were added </returns>
+        /// <exception cref="InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="ArgumentException"> if reportColumns list is empty or exceeds 400 items </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async Task<IList<ReportColumn>> AddReportColumnsAsync(long reportId, IEnumerable<ReportColumn> reportColumns, CancellationToken cancellationToken = default)
+        {
+            Utils.ThrowIfNull(reportColumns);
+
+            int columnCount = reportColumns.Count();
+            if (columnCount == 0)
+            {
+                throw new ArgumentException("reportColumns list must contain at least one item");
+            }
+
+            string path = "reports/" + reportId + "/columns";
+            IList<ReportColumn> addedReportColumns = await this.PostAndReceiveListAsync<IEnumerable<ReportColumn>, ReportColumn>(path, reportColumns, typeof(ReportColumn), cancellationToken).ConfigureAwait(false);
+            return addedReportColumns;
+        }
+
+        /// <summary>
+        /// <para>
         /// Create a new report by specifying name, destination, scope, columns and definition.
         /// </para>
         /// <para>It mirrors to the following Smartsheet REST API method: POST /reports</para>
@@ -492,6 +745,26 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public CreateReportResult CreateReport(CreateReportRequest request)
+        {
+            return this.CreateReportAsync(request).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>
+        /// Create a new report by specifying name, destination, scope, columns and definition.
+        /// </para>
+        /// <para>It mirrors to the following Smartsheet REST API method: POST /reports</para>
+        /// </summary>
+        /// <param name="request"> the create report request containing name, destination, scope, columns, and optional definition </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the created report result containing id, name, accessLevel, and permalink </returns>
+        /// <exception cref="InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async Task<CreateReportResult> CreateReportAsync(CreateReportRequest request, CancellationToken cancellationToken = default)
         {
             Utils.ThrowIfNull(request);
 
@@ -507,7 +780,7 @@ namespace Smartsheet.Api.Internal
 
             httpRequest.Entity = serializeToEntity(request);
 
-            HttpResponse response = smartsheet.HttpClient.Request(httpRequest);
+            HttpResponse response = await smartsheet.HttpClient.RequestAsync(httpRequest, cancellationToken).ConfigureAwait(false);
 
             CreateReportResult result;
             switch (response.StatusCode)

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/SheetRowResourcesImpl.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/SheetRowResourcesImpl.cs
@@ -26,6 +26,8 @@ namespace Smartsheet.Api.Internal
     using System.Net;
     using System;
     using System.Text;
+    using System.Threading.Tasks;
+    using System.Threading;
 
     /// <summary>
     /// This is the implementation of the SheetRowResources.
@@ -74,11 +76,35 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual IList<Row> AddRows(long sheetId, IEnumerable<Row> rows)
         {
+            return this.AddRowsAsync(sheetId, rows).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Asynchronously inserts one or more rows into the Sheet specified in the URL.</para>
+        /// 
+        /// <para>It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/rows</para>
+        /// <remarks>If multiple rows are specified in the request, all rows must be inserted at the same location 
+        /// (i.e. the toTop, toBottom, parentId, siblingId, and above attributes must be the same for all rows in the request).</remarks>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id </param>
+        /// <param name="rows"> one or more rows </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the list of created Rows </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task<IList<Row>> AddRowsAsync(long sheetId, IEnumerable<Row> rows, CancellationToken cancellationToken = default)
+        {
             foreach (Row row in rows)
             {
                 row.Id = null;
             }
-            return this.PostAndReceiveList<IEnumerable<Row>, Row>("sheets/" + sheetId + "/rows", rows, typeof(Row));
+
+            IList<Row> addedRows = await this.PostAndReceiveListAsync<IEnumerable<Row>, Row>("sheets/" + sheetId + "/rows", rows, typeof(Row), cancellationToken).ConfigureAwait(false);
+            return addedRows;
         }
 
         /// <summary>
@@ -98,6 +124,28 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual BulkItemRowResult AddRowsAllowPartialSuccess(long sheetId, IEnumerable<Row> rows)
+        {
+            return this.AddRowsAllowPartialSuccessAsync(sheetId, rows).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Inserts one or more rows into the Sheet specified in the URL with allowPartialSuccess.</para>
+        /// 
+        /// <para>It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/rows?allowPartialSuccess=true</para>
+        /// <remarks>If multiple rows are specified in the request, all rows must be inserted at the same location 
+        /// (i.e. the toTop, toBottom, parentId, siblingId, and above attributes must be the same for all rows in the request).</remarks>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id </param>
+        /// <param name="rows"> one or more rows </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the list of created Rows </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task<BulkItemRowResult> AddRowsAllowPartialSuccessAsync(long sheetId, IEnumerable<Row> rows, CancellationToken cancellationToken = default)
         {
             IDictionary<string, string> parameters = new Dictionary<string, string>();
             parameters.Add("allowPartialSuccess", "true");
@@ -119,7 +167,7 @@ namespace Smartsheet.Api.Internal
 
             request.Entity = serializeToEntity<IEnumerable<Row>>(rows);
 
-            HttpResponse response = this.Smartsheet.HttpClient.Request(request);
+            HttpResponse response = await this.Smartsheet.HttpClient.RequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             BulkItemRowResult bulkItemResult = null;
             switch (response.StatusCode)
@@ -154,6 +202,27 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual Row GetRow(long sheetId, long rowId, IEnumerable<RowInclusion>? include, IEnumerable<RowExclusion>? exclude)
         {
+            return this.GetRowAsync(sheetId, rowId, include, exclude).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Asynchronously gets the Row specified in the URL.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/rows/{rowId}</para>
+        /// </summary>
+        /// <param name="include"> comma-separated list of elements to include in the response. </param>
+        /// <param name="exclude"> a comma-separated list of optional objects to exclude in the response. </param>
+        /// <param name="sheetId"> the sheetId </param>
+        /// <param name="rowId"> the rowId </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the row object </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task<Row> GetRowAsync(long sheetId, long rowId, IEnumerable<RowInclusion>? include, IEnumerable<RowExclusion>? exclude, CancellationToken cancellationToken = default)
+        {
             Dictionary<string, string> parameters = new Dictionary<string, string>();
             if (include != null)
             {
@@ -163,7 +232,8 @@ namespace Smartsheet.Api.Internal
             {
                 parameters.Add("exclude", QueryUtil.GenerateCommaSeparatedList(exclude));
             }
-            return this.GetResource<Row>("sheets/" + sheetId + "/rows/" + rowId + QueryUtil.GenerateUrl(null, parameters), typeof(Row));
+            Row row = await this.GetResourceAsync<Row>("sheets/" + sheetId + "/rows/" + rowId + QueryUtil.GenerateUrl(null, parameters), typeof(Row), cancellationToken).ConfigureAwait(false);
+            return row;
         }
 
         /// <summary>
@@ -187,6 +257,31 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual CopyOrMoveRowResult CopyRowsToAnotherSheet(long sheetId, CopyOrMoveRowDirective directive, IEnumerable<CopyRowInclusion>? include, bool? ignoreRowsNotFound)
         {
+            return this.CopyRowsToAnotherSheetAsync(sheetId, directive, include, ignoreRowsNotFound).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Asynchronously copies Row(s) from the Sheet specified in the URL to (the bottom of) another sheet.</para>
+        /// 
+        /// <para>It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/rows/copy</para>
+        /// <remarks>Up to 5,000 row IDs can be specified in the request, 
+        /// but if the total number of rows in the destination sheet after the copy exceeds the Smartsheet row limit, 
+        /// an error response will be returned.</remarks>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id </param>
+        /// <param name="include"> objects to include </param>
+        /// <param name="ignoreRowsNotFound"> ignoreRowsNotFound </param>
+        /// <param name="directive"> directive </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> CopyOrMoveRowResult object </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task<CopyOrMoveRowResult> CopyRowsToAnotherSheetAsync(long sheetId, CopyOrMoveRowDirective directive, IEnumerable<CopyRowInclusion>? include, bool? ignoreRowsNotFound, CancellationToken cancellationToken = default)
+        {
             Utility.Utility.ThrowIfNull(directive);
             IDictionary<string, string> parameters = new Dictionary<string, string>();
             if (include != null)
@@ -197,7 +292,8 @@ namespace Smartsheet.Api.Internal
             {
                 parameters.Add("ignoreRowsNotFound", ignoreRowsNotFound.ToString().ToLower());
             }
-            return this.CreateResource<CopyOrMoveRowResult, CopyOrMoveRowDirective>(QueryUtil.GenerateUrl("sheets/" + sheetId + "/rows/copy", parameters), directive);
+            CopyOrMoveRowResult copyOrMoveRowResult = await this.CreateResourceAsync<CopyOrMoveRowResult, CopyOrMoveRowDirective>(QueryUtil.GenerateUrl("sheets/" + sheetId + "/rows/copy", parameters), directive, cancellationToken).ConfigureAwait(false);
+            return copyOrMoveRowResult;
         }
 
 
@@ -218,6 +314,27 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual IList<long> DeleteRows(long sheetId, IEnumerable<long> ids, bool? ignoreRowsNotFound)
         {
+            return this.DeleteRowsAsync(sheetId, ids, ignoreRowsNotFound).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Asynchronously deletes one or more row(s) from the Sheet</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: DELETE /sheets/{sheetId}/rows?ids={rowId1},{rowId2},{rowId3}...</para>
+        /// <remarks>This operation will delete ALL child Rows of the specified Row(s).</remarks>
+        /// </summary>
+        /// <param name="sheetId"> The sheet ID </param>
+        /// <param name="ids"> The list of row IDs </param>
+        /// <param name="ignoreRowsNotFound"> If set to false and any of the specified Row IDs are not found, no rows will be deleted, and the “not found” error will be returned.</param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns>Row IDs corresponding to all rows that were successfully deleted (including any child rows of rows specified in the URL).</returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task<IList<long>> DeleteRowsAsync(long sheetId, IEnumerable<long> ids, bool? ignoreRowsNotFound, CancellationToken cancellationToken = default)
+        {
             Utility.Utility.ThrowIfNull(ids);
             IDictionary<string, string> parameters = new Dictionary<string, string>();
             parameters.Add("ids", QueryUtil.GenerateCommaSeparatedList(ids));
@@ -225,7 +342,8 @@ namespace Smartsheet.Api.Internal
             {
                 parameters.Add("ignoreRowsNotFound", ignoreRowsNotFound.Value.ToString());
             }
-            return this.DeleteResource<IList<long>>(QueryUtil.GenerateUrl("sheets/" + sheetId + "/rows", parameters));
+            IList<long> deletedRows = await this.DeleteResourceAsync<IList<long>>(QueryUtil.GenerateUrl("sheets/" + sheetId + "/rows", parameters), cancellationToken).ConfigureAwait(false);
+            return deletedRows;
         }
 
         /// <summary>
@@ -250,6 +368,32 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual CopyOrMoveRowResult MoveRowsToAnotherSheet(long sheetId, CopyOrMoveRowDirective directive, IEnumerable<MoveRowInclusion>? include, bool? ignoreRowsNotFound)
         {
+            return this.MoveRowsToAnotherSheetAsync(sheetId, directive, include, ignoreRowsNotFound).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Asynchronously moves Row(s) from the Sheet specified in the URL to (the bottom of) another sheet.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/rows/copy</para>
+        /// <remarks><para>Up to 5,000 row IDs can be specified in the request, 
+        /// but if the total number of rows in the destination sheet after the copy exceeds the Smartsheet row limit, 
+        /// an error response will be returned.</para>
+        /// <para>Any child rows of the rows specified in the request will also be moved. 
+        /// Parent-child relationships amongst rows will be preserved within the destination sheet.</para></remarks>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id </param>
+        /// <param name="ignoreRowsNotFound"> ignoreRowsNotFound </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <param name="directive"> directive </param>
+        /// <param name="include">the elements to include.</param>
+        /// <returns> CopyOrMoveRowResult object </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task<CopyOrMoveRowResult> MoveRowsToAnotherSheetAsync(long sheetId, CopyOrMoveRowDirective directive, IEnumerable<MoveRowInclusion>? include, bool? ignoreRowsNotFound, CancellationToken cancellationToken = default)
+        {
             Utility.Utility.ThrowIfNull(directive);
             IDictionary<string, string> parameters = new Dictionary<string, string>();
             if (include != null)
@@ -260,7 +404,8 @@ namespace Smartsheet.Api.Internal
             {
                 parameters.Add("ignoreRowsNotFound", ignoreRowsNotFound.ToString().ToLower());
             }
-            return this.CreateResource<CopyOrMoveRowResult, CopyOrMoveRowDirective>(QueryUtil.GenerateUrl("sheets/" + sheetId + "/rows/move", parameters), directive);
+            CopyOrMoveRowResult copyOrMoveRowResult = await this.CreateResourceAsync<CopyOrMoveRowResult, CopyOrMoveRowDirective>(QueryUtil.GenerateUrl("sheets/" + sheetId + "/rows/move", parameters), directive, cancellationToken).ConfigureAwait(false);
+            return copyOrMoveRowResult;
         }
 
 
@@ -291,7 +436,38 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual void SendRows(long sheetId, MultiRowEmail email)
         {
-            this.CreateResource<MultiRowEmail>("sheets/" + sheetId + "/rows/emails", typeof(MultiRowEmail), email);
+            this.SendRowsAsync(sheetId, email).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Asynchronously sends one or more Rows via email.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/rows/emails</para>
+        /// </summary>
+        /// <param name="sheetId"> The sheet Id </param>
+        /// <param name="email"> The email. The columns included for each row in the email will be populated according to the following rules:
+        /// <list type="bullet">
+        /// <item><description>
+        /// If the columnIds attribute of the MultiRowEmail object is specified as an array of column IDs, those specific columns will be included.
+        /// </description></item>
+        /// <item><description>
+        /// If the columnIds attribute of the MultiRowEmail object is omitted, all columns except hidden columns shall be included.
+        /// </description></item>
+        /// <item><description>
+        /// If the columnIds attribute of the MultiRowEmail object is specified as empty, no columns shall be included.
+        /// (Note: In this case, either includeAttachments:true or includeDiscussions:true must be specified.)
+        /// </description></item>
+        /// </list>
+        /// </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async virtual Task SendRowsAsync(long sheetId, MultiRowEmail email, CancellationToken cancellationToken = default)
+        {
+            await this.CreateResourceAsync<MultiRowEmail>("sheets/" + sheetId + "/rows/emails", typeof(MultiRowEmail), email, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -311,7 +487,29 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public virtual IList<Row> UpdateRows(long sheetId, IEnumerable<Row> rows)
         {
-            return this.PutAndReceiveList<IEnumerable<Row>, Row>("sheets/" + sheetId + "/rows", rows, typeof(Row));
+            return this.UpdateRowsAsync(sheetId, rows).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Asynchronously updates cell values in the specified row(s), expands/collapses the specified row(s), 
+        /// and/or modifies the position of specified rows (including indenting/outdenting).</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: PUT /sheets/{sheetId}/rows</para>
+        /// <remarks>If a row’s position is updated, all child rows are moved with the row.</remarks>
+        /// </summary>
+        /// <param name="sheetId"> the sheetId </param>
+        /// <param name="rows"> the list of rows to update </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the row object </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public virtual async Task<IList<Row>> UpdateRowsAsync(long sheetId, IEnumerable<Row> rows, CancellationToken cancellationToken = default)
+        {
+            IList<Row> updatedRows = await this.PutAndReceiveListAsync<IEnumerable<Row>, Row>("sheets/" + sheetId + "/rows", rows, typeof(Row), cancellationToken).ConfigureAwait(false);
+            return updatedRows;
         }
 
         /// <summary>
@@ -331,6 +529,27 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         public BulkItemRowResult UpdateRowsAllowPartialSuccess(long sheetId, IEnumerable<Row> rows)
         {
+            return this.UpdateRowsAllowPartialSuccessAsync(sheetId, rows).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Asynchronously updates cell values in the specified row(s), expands/collapses the specified row(s), 
+        /// and/or modifies the position of specified rows (including indenting/outdenting).</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: PUT /sheets/{sheetId}/rows?allowPartialSuccess=true</para>
+        /// <remarks>If a row’s position is updated, all child rows are moved with the row.</remarks>
+        /// </summary>
+        /// <param name="sheetId">the sheetId</param>
+        /// <param name="rows">the list of rows to update</param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the row object </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public async Task<BulkItemRowResult> UpdateRowsAllowPartialSuccessAsync(long sheetId, IEnumerable<Row> rows, CancellationToken cancellationToken = default)
+        {
             IDictionary<string, string> parameters = new Dictionary<string, string>();
             parameters.Add("allowPartialSuccess", "true");
 
@@ -346,7 +565,7 @@ namespace Smartsheet.Api.Internal
 
             request.Entity = serializeToEntity<IEnumerable<Row>>(rows);
 
-            HttpResponse response = this.Smartsheet.HttpClient.Request(request);
+            HttpResponse response = await this.Smartsheet.HttpClient.RequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             BulkItemRowResult bulkItemResult = null;
             switch (response.StatusCode)

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/ReportResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/ReportResources.cs
@@ -97,7 +97,7 @@ namespace Smartsheet.Api
         Report GetReport(long reportId, IEnumerable<ReportInclusion>? include = null, int? pageSize = null, int? page = null, int? level = null);
 
         /// <summary>
-        /// <para>Gets the Report, including one page of Rows, and optionally populated with Discussions, Attachments, and source Sheets.</para>
+        /// <para>Asynchronously gets the Report, including one page of Rows, and optionally populated with Discussions, Attachments, and source Sheets.</para>
         /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{reportId}</para>
         /// </summary>
         /// <remarks>This method returns the top 100 rows. To get more or less rows please use the other overloaded versions of this method</remarks>
@@ -141,7 +141,7 @@ namespace Smartsheet.Api
         PaginatedResult<Report> ListReports(PaginationParameters? paging = null, DateTime? modifiedSince = null);
 
         /// <summary>
-        /// <para>Gets the list of all Reports that the User has access to, in alphabetical order, by name.</para>
+        /// <para>Asynchronously gets the list of all Reports that the User has access to, in alphabetical order, by name.</para>
         /// <para>It mirrors to the following Smartsheet REST API method: GET /reports</para>
         /// </summary>
         /// <param name="paging">the pagination</param>
@@ -209,7 +209,7 @@ namespace Smartsheet.Api
         void SendReport(long reportId, SheetEmail email);
 
         /// <summary>
-        /// <para>Send a report as a PDF attachment via Email to the designated recipients.</para>
+        /// <para>Asynchronously send a report as a PDF attachment via Email to the designated recipients.</para>
         /// 
         /// <para>It mirrors to the following Smartsheet REST API method: POST /reports/{reportId}/emails</para>
         /// </summary>
@@ -239,7 +239,7 @@ namespace Smartsheet.Api
         void DeleteReport(long reportId);
 
         /// <summary>
-        /// <para>Deletes a report.</para>
+        /// <para>Asynchronously deletes a report.</para>
         /// 
         /// <para>Mirrors the following Smartsheet REST API method: DELETE /reports/{reportId}</para>
         /// </summary>
@@ -272,7 +272,7 @@ namespace Smartsheet.Api
         ReportPublish GetPublishStatus(long reportId);
 
         /// <summary>
-        /// <para>Get the publish status of a report.</para>
+        /// <para>Asynchronously get the publish status of a report.</para>
         /// 
         /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{id}/publish</para>
         /// </summary>
@@ -313,7 +313,7 @@ namespace Smartsheet.Api
 
         /// <summary>
         /// <para>
-        /// Sets the publish status of a report and returns the new status, including the URLs of any enabled publishing.
+        /// Asynchronously sets the publish status of a report and returns the new status, including the URLs of any enabled publishing.
         /// </para>
         /// 
         /// <para>It mirrors to the following Smartsheet REST API method: PUT /reports/{id}/publish</para>
@@ -345,7 +345,7 @@ namespace Smartsheet.Api
         void UpdateReportDefinition(long reportId, ReportDefinition reportDefinition);
 
         /// <summary>
-        /// Update a Report's definition based on the specified ID
+        /// Asynchronously update a Report's definition based on the specified ID
         /// <para>Note:</para>
         /// <para>This endpoint supports partial updates <b>only on root level</b> properties of the report definition, such as <c>filters</c>, <c>groupingCriteria</c> and <c>summarizingCriteria</c>. For example, you can update the report's filters without affecting its grouping criteria. However, nested properties within these objects, such as a specific filter or grouping criterion, cannot be updated individually and require a full replacement of the respective section.</para>
         /// 
@@ -374,7 +374,7 @@ namespace Smartsheet.Api
 
         /// <summary>
         /// <para>
-        /// Adds one or more specified sheet or workspace to the report scope.
+        /// Asynchronously adds one or more specified sheet or workspace to the report scope.
         /// </para>
         /// </summary>
         /// <param name="reportId"> the reportId </param>
@@ -407,7 +407,7 @@ namespace Smartsheet.Api
 
         /// <summary>
         /// <para>
-        /// Removes one or more specified sheet or workspace from the report scope.
+        /// Asynchronously removes one or more specified sheet or workspace from the report scope.
         /// </para>
         /// </summary>
         /// <param name="reportId"> the reportId </param>
@@ -442,7 +442,7 @@ namespace Smartsheet.Api
 
         /// <summary>
         /// <para>
-        /// Add columns to a report specified by a report ID. Note: all indexes of the columns must be equal.
+        /// Asynchronously add columns to a report specified by a report ID. Note: all indexes of the columns must be equal.
         /// </para>
         /// <para>It mirrors to the following Smartsheet REST API method: POST /reports/{reportId}/columns</para>
         /// </summary>
@@ -474,6 +474,23 @@ namespace Smartsheet.Api
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         CreateReportResult CreateReport(CreateReportRequest request);
+
+        /// <summary>
+        /// <para>
+        /// Asynchronously create a new report by specifying name, destination, scope, columns and definition.
+        /// </para>
+        /// <para>It mirrors to the following Smartsheet REST API method: POST /reports</para>
+        /// </summary>
+        /// <param name="request"> the create report request containing name, destination, scope, columns, and optional definition </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the created report result containing id, name, accessLevel, and permalink </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<CreateReportResult> CreateReportAsync(CreateReportRequest request, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// <para>Gets the path (workspace/folder hierarchy) of the specified report.</para>

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/ReportResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/ReportResources.cs
@@ -19,6 +19,8 @@ using System.Collections.Generic;
 using Smartsheet.Api.Models;
 using System.IO;
 using System;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace Smartsheet.Api
 {
@@ -51,6 +53,28 @@ namespace Smartsheet.Api
         Report GetReport(long reportId, IEnumerable<ReportInclusion>? include = null, int? pageSize = null, int? page = null);
 
         /// <summary>
+        /// <para>Asynchronously gets the Report, including one page of Rows, and optionally populated with Discussions, Attachments, and source Sheets.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{reportId}</para>
+        /// </summary>
+        /// <remarks>This method returns the top 100 rows. To get more or less rows please use the other overloaded versions of this method</remarks>
+        /// <param name="reportId"> the Id of the report </param>
+        /// <param name="include"> used to specify the optional objects to include. </param>
+        /// <param name="pageSize">(optional): Number of rows per page. If not specified, the default value is 100.
+        /// This operation can return a maximum of 500 rows per page.</param>
+        /// <param name="page">(optional): Which page number (1-based) to return. 
+        /// If not specified, the default value is 1. If a page number is specified that is greater than the number of total pages, the last page will be returned.</param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the report resource (note that if there is no such resource, this method will throw 
+        /// ResourceNotFoundException rather than returning null). </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<Report> GetReportAsync(long reportId, IEnumerable<ReportInclusion>? include = null, int? pageSize = null, int? page = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// <para>Gets the Report, including one page of Rows, and optionally populated with Discussions, Attachments, and source Sheets.</para>
         /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{reportId}</para>
         /// </summary>
@@ -73,6 +97,29 @@ namespace Smartsheet.Api
         Report GetReport(long reportId, IEnumerable<ReportInclusion>? include = null, int? pageSize = null, int? page = null, int? level = null);
 
         /// <summary>
+        /// <para>Gets the Report, including one page of Rows, and optionally populated with Discussions, Attachments, and source Sheets.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{reportId}</para>
+        /// </summary>
+        /// <remarks>This method returns the top 100 rows. To get more or less rows please use the other overloaded versions of this method</remarks>
+        /// <param name="reportId"> the Id of the report </param>
+        /// <param name="include"> used to specify the optional objects to include. </param>
+        /// <param name="pageSize">(optional): Number of rows per page. If not specified, the default value is 100.
+        /// This operation can return a maximum of 500 rows per page.</param>
+        /// <param name="page">(optional): Which page number (1-based) to return. 
+        /// If not specified, the default value is 1. If a page number is specified that is greater than the number of total pages, the last page will be returned.</param>
+        /// <param name="level">(optional): compatiblity level</param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the report resource (note that if there is no such resource, this method will throw 
+        /// ResourceNotFoundException rather than returning null). </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<Report> GetReportAsync(long reportId, IEnumerable<ReportInclusion>? include = null, int? pageSize = null, int? page = null, int? level = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// <para>Gets the list of all Reports that the User has access to, in alphabetical order, by name.</para>
         /// <para>It mirrors to the following Smartsheet REST API method: GET /reports</para>
         /// </summary>
@@ -92,6 +139,28 @@ namespace Smartsheet.Api
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         PaginatedResult<Report> ListReports(PaginationParameters? paging = null, DateTime? modifiedSince = null);
+
+        /// <summary>
+        /// <para>Gets the list of all Reports that the User has access to, in alphabetical order, by name.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /reports</para>
+        /// </summary>
+        /// <param name="paging">the pagination</param>
+        /// <param name="modifiedSince">restrict results to reports modified on or after the specified date</param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns>A list of Report objects limited to the following attributes:
+        /// <list type="bullet">
+        /// <item><description>id</description></item>
+        /// <item><description>name</description></item>
+        /// <item><description>accessLevel</description></item>
+        /// <item><description>permalink</description></item>
+        /// </list></returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<PaginatedResult<Report>> ListReportsAsync(PaginationParameters? paging = null, DateTime? modifiedSince = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// <para>Gets the Report in the format specified, based on the Report ID.</para>
@@ -140,6 +209,22 @@ namespace Smartsheet.Api
         void SendReport(long reportId, SheetEmail email);
 
         /// <summary>
+        /// <para>Send a report as a PDF attachment via Email to the designated recipients.</para>
+        /// 
+        /// <para>It mirrors to the following Smartsheet REST API method: POST /reports/{reportId}/emails</para>
+        /// </summary>
+        /// <param name="reportId"> the reportId </param>
+        /// <param name="email"> the Email </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task SendReportAsync(long reportId, SheetEmail email, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// <para>Deletes a report.</para>
         /// 
         /// <para>Mirrors the following Smartsheet REST API method: DELETE /reports/{reportId}</para>
@@ -152,6 +237,21 @@ namespace Smartsheet.Api
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         void DeleteReport(long reportId);
+
+        /// <summary>
+        /// <para>Deletes a report.</para>
+        /// 
+        /// <para>Mirrors the following Smartsheet REST API method: DELETE /reports/{reportId}</para>
+        /// </summary>
+        /// <param name="reportId"> the report Id </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task DeleteReportAsync(long reportId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// <para>Get the publish status of a report.</para>
@@ -170,6 +270,25 @@ namespace Smartsheet.Api
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         ReportPublish GetPublishStatus(long reportId);
+
+        /// <summary>
+        /// <para>Get the publish status of a report.</para>
+        /// 
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{id}/publish</para>
+        /// </summary>
+        /// <param name="reportId"> the reportId </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns>
+        /// The report publish status (note that if there is no such resource, this method will 
+        /// throw ResourceNotFoundException rather than returning null).
+        /// </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<ReportPublish> GetPublishStatusAsync(long reportId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// <para>
@@ -193,6 +312,28 @@ namespace Smartsheet.Api
         ReportPublish UpdatePublishStatus(long reportId, ReportPublish reportPublish);
 
         /// <summary>
+        /// <para>
+        /// Sets the publish status of a report and returns the new status, including the URLs of any enabled publishing.
+        /// </para>
+        /// 
+        /// <para>It mirrors to the following Smartsheet REST API method: PUT /reports/{id}/publish</para>
+        /// </summary>
+        /// <param name="reportId"> the reportId </param>
+        /// <param name="reportPublish"> the ReportPublish object</param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns>
+        /// The report publish status (note that if there is no such resource, this method will 
+        /// throw ResourceNotFoundException rather than returning null).
+        /// </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<ReportPublish> UpdatePublishStatusAsync(long reportId, ReportPublish reportPublish, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Update a Report's definition based on the specified ID
         /// <para>Note:</para>
         /// <para>This endpoint supports partial updates <b>only on root level</b> properties of the report definition, such as <c>filters</c>, <c>groupingCriteria</c> and <c>summarizingCriteria</c>. For example, you can update the report's filters without affecting its grouping criteria. However, nested properties within these objects, such as a specific filter or grouping criterion, cannot be updated individually and require a full replacement of the respective section.</para>
@@ -202,6 +343,18 @@ namespace Smartsheet.Api
         /// <param name="reportId"> the reportId </param>
         /// <param name="reportDefinition"> the ReportDefinition object </param>
         void UpdateReportDefinition(long reportId, ReportDefinition reportDefinition);
+
+        /// <summary>
+        /// Update a Report's definition based on the specified ID
+        /// <para>Note:</para>
+        /// <para>This endpoint supports partial updates <b>only on root level</b> properties of the report definition, such as <c>filters</c>, <c>groupingCriteria</c> and <c>summarizingCriteria</c>. For example, you can update the report's filters without affecting its grouping criteria. However, nested properties within these objects, such as a specific filter or grouping criterion, cannot be updated individually and require a full replacement of the respective section.</para>
+        /// 
+        /// <para>It mirrors to the following Smartsheet REST API method: PUT /reports/{reportId}/definition</para>
+        /// </summary>
+        /// <param name="reportId"> the reportId </param>
+        /// <param name="reportDefinition"> the ReportDefinition object </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        Task UpdateReportDefinitionAsync(long reportId, ReportDefinition reportDefinition, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// <para>
@@ -221,6 +374,23 @@ namespace Smartsheet.Api
 
         /// <summary>
         /// <para>
+        /// Adds one or more specified sheet or workspace to the report scope.
+        /// </para>
+        /// </summary>
+        /// <param name="reportId"> the reportId </param>
+        /// <param name="scopes"> an array of one or more objects denoting the sheets or workspaces associated with the report </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="ArgumentException"> if scopes are empty </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task AddReportScopeAsync(long reportId, IEnumerable<ReportScopeInclusion> scopes, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// <para>
         /// Removes one or more specified sheet or workspace from the report scope.
         /// </para>
         /// </summary>
@@ -234,6 +404,23 @@ namespace Smartsheet.Api
         /// <exception cref="ArgumentException"> if scopes are empty </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         void RemoveReportScope(long reportId, IEnumerable<ReportScopeInclusion> scopes);
+
+        /// <summary>
+        /// <para>
+        /// Removes one or more specified sheet or workspace from the report scope.
+        /// </para>
+        /// </summary>
+        /// <param name="reportId"> the reportId </param>
+        /// <param name="scopes"> an array of one or more objects denoting the sheets or workspaces associated with the report </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="ArgumentException"> if scopes are empty </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task RemoveReportScopeAsync(long reportId, IEnumerable<ReportScopeInclusion> scopes, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// <para>
@@ -255,6 +442,25 @@ namespace Smartsheet.Api
 
         /// <summary>
         /// <para>
+        /// Add columns to a report specified by a report ID. Note: all indexes of the columns must be equal.
+        /// </para>
+        /// <para>It mirrors to the following Smartsheet REST API method: POST /reports/{reportId}/columns</para>
+        /// </summary>
+        /// <param name="reportId"> the reportId </param>
+        /// <param name="reportColumns"> list of report columns to be added (minItems: 1, maxItems: 400) </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> list of report columns that were added </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="ArgumentException"> if reportColumns list is empty or exceeds 400 items </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<IList<ReportColumn>> AddReportColumnsAsync(long reportId, IEnumerable<ReportColumn> reportColumns, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// <para>
         /// Create a new report by specifying name, destination, scope, columns and definition.
         /// </para>
         /// <para>It mirrors to the following Smartsheet REST API method: POST /reports</para>
@@ -268,5 +474,22 @@ namespace Smartsheet.Api
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         CreateReportResult CreateReport(CreateReportRequest request);
+
+        /// <summary>
+        /// <para>
+        /// Create a new report by specifying name, destination, scope, columns and definition.
+        /// </para>
+        /// <para>It mirrors to the following Smartsheet REST API method: POST /reports</para>
+        /// </summary>
+        /// <param name="request"> the create report request containing name, destination, scope, columns, and optional definition </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the created report result containing id, name, accessLevel, and permalink </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<CreateReportResult> CreateReportAsync(CreateReportRequest request, CancellationToken cancellationToken = default);
     }
 }

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/SheetRowResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/SheetRowResources.cs
@@ -23,6 +23,8 @@ namespace Smartsheet.Api
     using Api.Models;
     using System;
     using System.ComponentModel;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// This interface provides methods to access row resources that are associated to a sheet object.
@@ -48,6 +50,24 @@ namespace Smartsheet.Api
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         IList<Row> AddRows(long sheetId, IEnumerable<Row> rows);
 
+         /// <summary>
+        /// <para>Asynchronously inserts one or more rows into the Sheet specified in the URL.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/rows</para>
+        /// <remarks>If multiple rows are specified in the request, all rows must be inserted at the same location 
+        /// (i.e. the toTop, toBottom, parentId, siblingId, and above attributes must be the same for all rows in the request).</remarks>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id </param>
+        /// <param name="rows"> one or more rows </param>
+        /// <param name="cancellationToken">the cancellation token</param>
+        /// <returns> the list of created Rows </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<IList<Row>> AddRowsAsync(long sheetId, IEnumerable<Row> rows, CancellationToken cancellationToken = default);
+
         /// <summary>
         /// <para>Inserts one or more rows into the Sheet specified in the URL with allowPartialSuccess.</para>
         /// <para>It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/rows?allowPartialSuccess=true</para>
@@ -66,6 +86,24 @@ namespace Smartsheet.Api
         BulkItemRowResult AddRowsAllowPartialSuccess(long sheetId, IEnumerable<Row> rows);
 
         /// <summary>
+        /// <para>Asynchronously inserts one or more rows into the Sheet specified in the URL with allowPartialSuccess.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/rows?allowPartialSuccess=true</para>
+        /// <remarks>If multiple rows are specified in the request, all rows must be inserted at the same location 
+        /// (i.e. the toTop, toBottom, parentId, siblingId, and above attributes must be the same for all rows in the request).</remarks>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id </param>
+        /// <param name="rows"> one or more rows </param>
+        /// <param name="cancellationToken">the cancellation token</param>
+        /// <returns> the list of created Rows </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<BulkItemRowResult> AddRowsAllowPartialSuccessAsync(long sheetId, IEnumerable<Row> rows, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// <para>Gets the Row specified in the URL.</para>
         /// <para>It mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/rows/{rowId}</para>
         /// </summary>
@@ -81,6 +119,24 @@ namespace Smartsheet.Api
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         Row GetRow(long sheetId, long rowId, IEnumerable<RowInclusion>? include = null, IEnumerable<RowExclusion>? exclude = null);
+
+        /// <summary>
+        /// <para>Asynchronously gets the Row specified in the URL.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/rows/{rowId}</para>
+        /// </summary>
+        /// <param name="include"> comma-separated list of elements to include in the response. </param>
+        /// <param name="exclude"> a comma-separated list of optional objects to exclude in the response. </param>
+        /// <param name="sheetId"> the sheetId </param>
+        /// <param name="rowId"> the rowId </param>
+        /// <param name="cancellationToken">the cancellation token</param>
+        /// <returns> the row object </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<Row> GetRowAsync(long sheetId, long rowId, IEnumerable<RowInclusion>? include = null, IEnumerable<RowExclusion>? exclude = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// <para>Copies Row(s) from the Sheet specified in the URL to (the bottom of) another sheet.</para>
@@ -105,6 +161,29 @@ namespace Smartsheet.Api
         CopyOrMoveRowResult CopyRowsToAnotherSheet(long sheetId, CopyOrMoveRowDirective directive, IEnumerable<CopyRowInclusion>? include = null, bool? ignoreRowsNotFound = null);
 
         /// <summary>
+        /// <para>Asynchronously copies Row(s) from the Sheet specified in the URL to (the bottom of) another sheet.</para>
+        /// 
+        /// <para>It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/rows/copy</para>
+        /// <remarks>Up to 5,000 row IDs can be specified in the request, 
+        /// but if the total number of rows in the destination sheet after the copy exceeds the Smartsheet row limit, 
+        /// an error response will be returned.</remarks>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id to copy from </param>
+        /// <param name="include"> objects to include </param>
+        /// <param name="ignoreRowsNotFound"> default is false. If set to true, specifying row Ids that do not exist within the source sheet will not cause an error response.
+        /// If omitted or set to false, specifying row Ids that do not exist within the source sheet will cause an error response (and no rows will be copied). </param>
+        /// <param name="directive"> directive </param>
+        /// <param name="cancellationToken">the cancellation token</param>
+        /// <returns> CopyOrMoveRowResult object </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<CopyOrMoveRowResult> CopyRowsToAnotherSheetAsync(long sheetId, CopyOrMoveRowDirective directive, IEnumerable<CopyRowInclusion>? include = null, bool? ignoreRowsNotFound = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// <para>Deletes the Row specified in the URL.</para>
         /// <para>It mirrors to the following Smartsheet REST API method: DELETE /sheets/{sheetId}/rows/{rowId}</para>
         /// <remarks>This operation will delete ALL child Rows of the specified Row.</remarks>
@@ -121,6 +200,25 @@ namespace Smartsheet.Api
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         IList<long> DeleteRows(long sheetId, IEnumerable<long> ids, bool? ignoreRowsNotFound = null);
+
+        /// <summary>
+        /// <para>Asynchronously deletes the Row specified in the URL.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: DELETE /sheets/{sheetId}/rows/{rowId}</para>
+        /// <remarks>This operation will delete ALL child Rows of the specified Row.</remarks>
+        /// </summary>
+        /// <param name="sheetId"> the sheetId </param>
+        /// <param name="ids"> the row IDs </param>
+        /// <param name="ignoreRowsNotFound">If set to true, specifying row Ids that do not exist within the source sheet will not cause an error response.
+        /// If omitted or set to false, specifying row Ids that do not exist within the source sheet will cause an error response (and no rows will be copied).</param>
+        /// <param name="cancellationToken">the cancellation token</param>
+        /// <returns>Row IDs corresponding to all rows that were successfully deleted (including any child rows of rows specified in the URL).</returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<IList<long>> DeleteRowsAsync(long sheetId, IEnumerable<long> ids, bool? ignoreRowsNotFound = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// <para>Moves Row(s) from the Sheet specified in the URL to (the bottom of) another sheet.</para>
@@ -144,6 +242,30 @@ namespace Smartsheet.Api
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         CopyOrMoveRowResult MoveRowsToAnotherSheet(long sheetId, CopyOrMoveRowDirective directive, IEnumerable<MoveRowInclusion>? include = null, bool? ignoreRowsNotFound = null);
+
+        /// <summary>
+        /// <para>Asynchronously moves Row(s) from the Sheet specified in the URL to (the bottom of) another sheet.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/rows/copy</para>
+        /// <remarks><para>Up to 5,000 row IDs can be specified in the request, 
+        /// but if the total number of rows in the destination sheet after the copy exceeds the Smartsheet row limit, 
+        /// an error response will be returned.</para>
+        /// <para>Any child rows of the rows specified in the request will also be moved. 
+        /// Parent-child relationships amongst rows will be preserved within the destination sheet.</para></remarks>
+        /// </summary>
+        /// <param name="sheetId"> the sheet Id to move from </param>
+        /// <param name="ignoreRowsNotFound"> default is false. If set to true, specifying row Ids that do not exist within the source sheet will not cause an error response.
+        /// If omitted or set to false, specifying row Ids that do not exist within the source sheet will cause an error response (and no rows will be copied). </param>
+        /// <param name="directive"> directive </param>
+        /// <param name="include">the elements to include</param>
+        /// <param name="cancellationToken">the cancellation token</param>
+        /// <returns> CopyOrMoveRowResult object </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<CopyOrMoveRowResult> MoveRowsToAnotherSheetAsync(long sheetId, CopyOrMoveRowDirective directive, IEnumerable<MoveRowInclusion>? include = null, bool? ignoreRowsNotFound = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// <para>Sends one or more Rows via email.</para>
@@ -173,6 +295,34 @@ namespace Smartsheet.Api
         void SendRows(long sheetId, MultiRowEmail email);
 
         /// <summary>
+        /// <para>Asynchronously sends one or more Rows via email.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/rows/emails</para>
+        /// </summary>
+        /// <param name="sheetId"> The sheet Id </param>
+        /// <param name="email"> The email. The columns included for each row in the email will be populated according to the following rules:
+        /// <list type="bullet">
+        /// <item><description>
+        /// If the columnIds attribute of the MultiRowEmail object is specified as an array of column IDs, those specific columns will be included.
+        /// </description></item>
+        /// <item><description>
+        /// If the columnIds attribute of the MultiRowEmail object is omitted, all columns except hidden columns shall be included.
+        /// </description></item>
+        /// <item><description>
+        /// If the columnIds attribute of the MultiRowEmail object is specified as empty, no columns shall be included.
+        /// (Note: In this case, either includeAttachments:true or includeDiscussions:true must be specified.)
+        /// </description></item>
+        /// </list>
+        /// </param>
+        /// <param name="cancellationToken">the cancellation token</param>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task SendRowsAsync(long sheetId, MultiRowEmail email, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// <para>Updates cell values in the specified row(s), expands/collapses the specified row(s), 
         /// and/or modifies the position of specified rows (including indenting/outdenting).</para>
         /// <para>It mirrors to the following Smartsheet REST API method: PUT /sheets/{sheetId}/rows</para>
@@ -190,6 +340,24 @@ namespace Smartsheet.Api
         IList<Row> UpdateRows(long sheetId, IEnumerable<Row> rows);
 
         /// <summary>
+        /// <para>Asynchronously updates cell values in the specified row(s), expands/collapses the specified row(s), 
+        /// and/or modifies the position of specified rows (including indenting/outdenting).</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: PUT /sheets/{sheetId}/rows</para>
+        /// <remarks>If a row’s position is updated, all child rows are moved with the row.</remarks>
+        /// </summary>
+        /// <param name="sheetId">the sheetId</param>
+        /// <param name="rows">the list of rows to update</param>
+        /// <param name="cancellationToken">the cancellation token</param>
+        /// <returns> the row object </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<IList<Row>> UpdateRowsAsync(long sheetId, IEnumerable<Row> rows, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// <para>Updates cell values in the specified row(s), expands/collapses the specified row(s), 
         /// and/or modifies the position of specified rows (including indenting/outdenting).</para>
         /// <para>It mirrors to the following Smartsheet REST API method: PUT /sheets/{sheetId}/rows?allowPartialSuccess=true</para>
@@ -205,6 +373,24 @@ namespace Smartsheet.Api
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         BulkItemRowResult UpdateRowsAllowPartialSuccess(long sheetId, IEnumerable<Row> rows);
+
+        /// <summary>
+        /// <para>Asynchronously updates cell values in the specified row(s), expands/collapses the specified row(s), 
+        /// and/or modifies the position of specified rows (including indenting/outdenting).</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: PUT /sheets/{sheetId}/rows?allowPartialSuccess=true</para>
+        /// <remarks>If a row’s position is updated, all child rows are moved with the row.</remarks>
+        /// </summary>
+        /// <param name="sheetId">the sheetId</param>
+        /// <param name="rows">the list of rows to update</param>
+        /// <param name="cancellationToken">the cancellation token</param>
+        /// <returns> the row object </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        Task<BulkItemRowResult> UpdateRowsAllowPartialSuccessAsync(long sheetId, IEnumerable<Row> rows, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns the RowAttachmentResources object that provides access to attachment resources associated with Row Resources.


### PR DESCRIPTION
I went ahead and added async methods for the methods found in `ReportResources` and `SheetRowResources` following what was established for my last PR https://github.com/smartsheet/smartsheet-csharp-sdk/pull/195

We needed async versions of `PutAndReceiveList()` and `PostAndReceiveList()` within `AbstractResources`, so I've included those as well.

