### PR TITLE
Add reports endpoints for phase 2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Hardcode `paginationType=token` for `listWorkspaces`.
+- Support for GET /2.0/reports/{reportId}/definition (Get Report Definition)
+- Support for GET /2.0/reports/{reportId}/columns (List Report Columns)
+- Support for GET /2.0/reports/{reportId}/columns/{columnVirtualId} (Get Report Column)
+- Support for PUT /2.0/reports/{reportId}/columns/{columnVirtualId} (Update Report Column)
+- Support for DELETE /2.0/reports/{reportId}/columns/{columnVirtualId} (Delete Report Column)
+- Support for GET /2.0/reports/{reportId}/scope (List Report Scope)
 
 ## [7.0.0] - 2026-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Hardcode `paginationType=token` for `listWorkspaces`.
-- Support for GET /2.0/reports/{reportId}/definition (Get Report Definition)
-- Support for GET /2.0/reports/{reportId}/columns (List Report Columns)
-- Support for GET /2.0/reports/{reportId}/columns/{columnVirtualId} (Get Report Column)
-- Support for PUT /2.0/reports/{reportId}/columns/{columnVirtualId} (Update Report Column)
-- Support for DELETE /2.0/reports/{reportId}/columns/{columnVirtualId} (Delete Report Column)
-- Support for GET /2.0/reports/{reportId}/scope (List Report Scope)
+- Support for GET /2.0/reports/{reportId}/definition (Get Report Definition) via `ReportResources.GetReportDefinition`
+- Support for GET /2.0/reports/{reportId}/columns (List Report Columns) via `ReportResources.ListReportColumns`
+- Support for GET /2.0/reports/{reportId}/columns/{columnVirtualId} (Get Report Column) via `ReportResources.GetReportColumn`
+- Support for PUT /2.0/reports/{reportId}/columns/{columnVirtualId} (Update Report Column) via `ReportResources.UpdateReportColumn`
+- Support for DELETE /2.0/reports/{reportId}/columns/{columnVirtualId} (Delete Report Column) via `ReportResources.DeleteReportColumn`
+- Support for GET /2.0/reports/{reportId}/scope (List Report Scope) via `ReportResources.GetReportScope`
 
 ## [7.0.0] - 2026-06-08
 

--- a/mock-api-test-sdk-net80/reports/TestDeleteReportColumn.cs
+++ b/mock-api-test-sdk-net80/reports/TestDeleteReportColumn.cs
@@ -1,0 +1,95 @@
+using Smartsheet.Api;
+
+namespace mock_api_test_sdk_net80
+{
+    [TestClass]
+    public class TestDeleteReportColumn
+    {
+        [TestMethod]
+        public async Task TestDeleteReportColumnGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/delete-report-column/all-response-body-properties", requestId.ToString());
+
+            smartsheet.ReportResources.DeleteReportColumn(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+            Assert.IsNotNull(foundRequest);
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+
+            Assert.AreEqual(string.Format("/2.0/reports/{0}/columns/{1}", CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID), uri.AbsolutePath);
+            Assert.AreEqual("DELETE", foundRequest.Method);
+            Assert.AreEqual(string.Empty, uri.Query);
+        }
+
+        [TestMethod]
+        public void TestDeleteReportColumnError500Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>
+                smartsheet.ReportResources.DeleteReportColumn(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID)
+            );
+
+            Assert.IsTrue(exception.Message.Contains("Internal Server Error"));
+        }
+
+        [TestMethod]
+        public void TestDeleteReportColumnError404Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/404-response", requestId.ToString());
+
+            HelperFunctions.AssertRaisesException<SmartsheetException>(
+                () => smartsheet.ReportResources.DeleteReportColumn(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID),
+                "Not Found"
+            );
+        }
+
+        [TestMethod]
+        public async Task TestDeleteReportColumnAsyncGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/delete-report-column/all-response-body-properties", requestId.ToString());
+
+            await smartsheet.ReportResources.DeleteReportColumnAsync(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+            Assert.IsNotNull(foundRequest);
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+
+            Assert.AreEqual(string.Format("/2.0/reports/{0}/columns/{1}", CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID), uri.AbsolutePath);
+            Assert.AreEqual("DELETE", foundRequest.Method);
+            Assert.AreEqual(string.Empty, uri.Query);
+        }
+
+        [TestMethod]
+        public async Task TestDeleteReportColumnAsyncError500Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+
+            await HelperFunctions.AssertRaisesExceptionAsync<SmartsheetException>(
+                () => smartsheet.ReportResources.DeleteReportColumnAsync(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID),
+                "Internal Server Error"
+            );
+        }
+
+        [TestMethod]
+        public async Task TestDeleteReportColumnAsyncError404Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/404-response", requestId.ToString());
+
+            await HelperFunctions.AssertRaisesExceptionAsync<SmartsheetException>(
+                () => smartsheet.ReportResources.DeleteReportColumnAsync(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID),
+                "Not Found"
+            );
+        }
+    }
+}

--- a/mock-api-test-sdk-net80/reports/TestGetReportColumn.cs
+++ b/mock-api-test-sdk-net80/reports/TestGetReportColumn.cs
@@ -49,6 +49,26 @@ namespace mock_api_test_sdk_net80
         }
 
         [TestMethod]
+        public async Task TestGetReportColumnWithLevelGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/get-report-column/all-response-body-properties", requestId.ToString());
+
+            smartsheet.ReportResources.GetReportColumn(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID, 3);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+            var queryParams = System.Web.HttpUtility.ParseQueryString(uri.Query);
+
+            Assert.AreEqual($"/2.0/reports/{CommonTestConstants.TEST_REPORT_ID}/columns/{CommonTestConstants.TEST_COLUMN_VIRTUAL_ID}", uri.AbsolutePath);
+            Assert.AreEqual("GET", foundRequest.Method);
+            Assert.AreEqual("3", queryParams["level"]);
+        }
+
+        [TestMethod]
         public async Task TestGetReportColumnRequiredResponseProperties()
         {
             Guid requestId = Guid.NewGuid();

--- a/mock-api-test-sdk-net80/reports/TestGetReportColumn.cs
+++ b/mock-api-test-sdk-net80/reports/TestGetReportColumn.cs
@@ -1,0 +1,161 @@
+using Newtonsoft.Json;
+using Smartsheet.Api;
+using Smartsheet.Api.Models;
+
+namespace mock_api_test_sdk_net80
+{
+    [TestClass]
+    public class TestGetReportColumn
+    {
+        private static readonly ReportColumn EXPECTED_REQUIRED_RESPONSE = new ReportColumn
+        {
+            Index = 0,
+            Title = "Task Name",
+            Type = ColumnType.TEXT_NUMBER,
+            Primary = true
+        };
+
+        private static readonly ReportColumn EXPECTED_ALL_RESPONSE = new ReportColumn
+        {
+            VirtualId = 7001,
+            Index = 0,
+            Title = "Task Name",
+            Type = ColumnType.TEXT_NUMBER,
+            Primary = true,
+            Width = 150,
+            Hidden = false,
+            Validation = true,
+            Version = 0,
+            AutoNumberFormat = new AutoNumberFormat { Fill = "0001", Prefix = "TASK-", StartingNumber = 1, Suffix = "" }
+        };
+
+        [TestMethod]
+        public async Task TestGetReportColumnGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/get-report-column/all-response-body-properties", requestId.ToString());
+
+            smartsheet.ReportResources.GetReportColumn(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+
+            Assert.AreEqual($"/2.0/reports/{CommonTestConstants.TEST_REPORT_ID}/columns/{CommonTestConstants.TEST_COLUMN_VIRTUAL_ID}", uri.AbsolutePath);
+            Assert.AreEqual("GET", foundRequest.Method);
+            Assert.AreEqual(string.Empty, uri.Query);
+        }
+
+        [TestMethod]
+        public async Task TestGetReportColumnRequiredResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/get-report-column/required-response-body-properties", requestId.ToString());
+
+            ReportColumn result = smartsheet.ReportResources.GetReportColumn(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.AreEqual(JsonConvert.SerializeObject(EXPECTED_REQUIRED_RESPONSE), JsonConvert.SerializeObject(result));
+        }
+
+        [TestMethod]
+        public async Task TestGetReportColumnAllResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/get-report-column/all-response-body-properties", requestId.ToString());
+
+            ReportColumn result = smartsheet.ReportResources.GetReportColumn(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.AreEqual(JsonConvert.SerializeObject(EXPECTED_ALL_RESPONSE), JsonConvert.SerializeObject(result));
+        }
+
+        [TestMethod]
+        public void TestGetReportColumnError500Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>
+                smartsheet.ReportResources.GetReportColumn(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID)
+            );
+
+            Assert.IsTrue(exception.Message.Contains("Internal Server Error"));
+        }
+
+        [TestMethod]
+        public void TestGetReportColumnError404Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/404-response", requestId.ToString());
+
+            HelperFunctions.AssertRaisesException<SmartsheetException>(
+                () => smartsheet.ReportResources.GetReportColumn(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID),
+                "Not Found"
+            );
+        }
+
+        [TestMethod]
+        public async Task TestGetReportColumnAsyncGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/get-report-column/all-response-body-properties", requestId.ToString());
+
+            await smartsheet.ReportResources.GetReportColumnAsync(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+
+            Assert.AreEqual($"/2.0/reports/{CommonTestConstants.TEST_REPORT_ID}/columns/{CommonTestConstants.TEST_COLUMN_VIRTUAL_ID}", uri.AbsolutePath);
+            Assert.AreEqual("GET", foundRequest.Method);
+            Assert.AreEqual(string.Empty, uri.Query);
+        }
+
+        [TestMethod]
+        public async Task TestGetReportColumnAsyncAllResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/get-report-column/all-response-body-properties", requestId.ToString());
+
+            ReportColumn result = await smartsheet.ReportResources.GetReportColumnAsync(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.AreEqual(JsonConvert.SerializeObject(EXPECTED_ALL_RESPONSE), JsonConvert.SerializeObject(result));
+        }
+
+        [TestMethod]
+        public async Task TestGetReportColumnAsyncError500Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+
+            await HelperFunctions.AssertRaisesExceptionAsync<SmartsheetException>(
+                () => smartsheet.ReportResources.GetReportColumnAsync(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID),
+                "Internal Server Error"
+            );
+        }
+
+        [TestMethod]
+        public async Task TestGetReportColumnAsyncError404Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/404-response", requestId.ToString());
+
+            await HelperFunctions.AssertRaisesExceptionAsync<SmartsheetException>(
+                () => smartsheet.ReportResources.GetReportColumnAsync(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID),
+                "Not Found"
+            );
+        }
+    }
+}

--- a/mock-api-test-sdk-net80/reports/TestGetReportDefinition.cs
+++ b/mock-api-test-sdk-net80/reports/TestGetReportDefinition.cs
@@ -1,0 +1,274 @@
+using Newtonsoft.Json;
+using Smartsheet.Api;
+using Smartsheet.Api.Models;
+
+namespace mock_api_test_sdk_net80
+{
+    [TestClass]
+    public class TestGetReportDefinition
+    {
+        private static readonly ReportDefinition EXPECTED_ALL = new ReportDefinition
+        {
+            Filters = new ReportFilterExpression
+            {
+                Operator = ReportFilterOperator.AND,
+                Criteria = new List<ReportFilterCriterion>
+                {
+                    new ReportFilterCriterion
+                    {
+                        Column = new ReportColumnIdentifier
+                        {
+                            Title = "Primary Column",
+                            Type = ColumnType.TEXT_NUMBER,
+                            Primary = true,
+                        },
+                        Operator = ReportFilterCriteriaOperator.EQUAL,
+                        Values = new List<ReportFilterValue> { new StringReportFilterValue("Test Value") },
+                    },
+                    new ReportFilterCriterion
+                    {
+                        Column = new ReportColumnIdentifier
+                        {
+                            Title = "Status",
+                            Type = ColumnType.PICKLIST,
+                        },
+                        Operator = ReportFilterCriteriaOperator.NOT_EQUAL,
+                        Values = new List<ReportFilterValue> { new StringReportFilterValue("Complete") },
+                    },
+                    new ReportFilterCriterion
+                    {
+                        Column = new ReportColumnIdentifier
+                        {
+                            Title = "Amount",
+                            Type = ColumnType.TEXT_NUMBER,
+                        },
+                        Operator = ReportFilterCriteriaOperator.GREATER_THAN,
+                        Values = new List<ReportFilterValue> { new NumberReportFilterValue(42) },
+                    },
+                    new ReportFilterCriterion
+                    {
+                        Column = new ReportColumnIdentifier
+                        {
+                            Type = ColumnType.DATETIME,
+                            SystemColumnType = SystemColumnType.MODIFIED_DATE,
+                        },
+                        Operator = ReportFilterCriteriaOperator.LESS_THAN,
+                        Values = new List<ReportFilterValue> { new DateReportFilterValue("2025-01-14") },
+                    },
+                    new ReportFilterCriterion
+                    {
+                        Column = new ReportColumnIdentifier
+                        {
+                            Title = "Assigned To",
+                            Type = ColumnType.CONTACT_LIST,
+                        },
+                        Operator = ReportFilterCriteriaOperator.EQUAL,
+                        Values = new List<ReportFilterValue> { new CurrentUserReportFilterValue() },
+                    },
+                    new ReportFilterCriterion
+                    {
+                        Column = new ReportColumnIdentifier
+                        {
+                            Title = "Notes",
+                            Type = ColumnType.TEXT_NUMBER,
+                        },
+                        Operator = ReportFilterCriteriaOperator.EQUAL,
+                        Values = new List<ReportFilterValue> { new NullReportFilterValue() },
+                    }
+                }
+            },
+            GroupingCriteria = new List<ReportGroupingCriterion>
+            {
+                new ReportGroupingCriterion
+                {
+                    Column = new ReportColumnIdentifier
+                    {
+                        Title = "Primary Column",
+                        Type = ColumnType.TEXT_NUMBER,
+                        Primary = true,
+                    },
+                    SortingDirection = SortDirection.ASCENDING,
+                    IsExpanded = true
+                },
+                new ReportGroupingCriterion
+                {
+                    Column = new ReportColumnIdentifier
+                    {
+                        Title = "Category",
+                        Type = ColumnType.TEXT_NUMBER,
+                    },
+                    SortingDirection = SortDirection.DESCENDING,
+                    IsExpanded = false
+                }
+            },
+            SummarizingCriteria = new List<ReportSummarizingCriterion>
+            {
+                new ReportSummarizingCriterion
+                {
+                    Column = new ReportColumnIdentifier
+                    {
+                        Title = "Primary Column",
+                        Type = ColumnType.TEXT_NUMBER,
+                        Primary = true,
+                    },
+                    AggregationType = ReportAggregationType.COUNT
+                },
+                new ReportSummarizingCriterion
+                {
+                    Column = new ReportColumnIdentifier
+                    {
+                        Title = "Amount",
+                        Type = ColumnType.TEXT_NUMBER,
+                    },
+                    AggregationType = ReportAggregationType.SUM
+                }
+            },
+            SortingCriteria = new List<ReportSortingCriterion>
+            {
+                new ReportSortingCriterion
+                {
+                    Column = new ReportColumnIdentifier
+                    {
+                        Title = "Primary Column",
+                        Type = ColumnType.TEXT_NUMBER,
+                        Primary = true,
+                    },
+                    SortingDirection = SortDirection.ASCENDING
+                },
+                new ReportSortingCriterion
+                {
+                    Column = new ReportColumnIdentifier
+                    {
+                        Type = ColumnType.DATETIME,
+                        SystemColumnType = SystemColumnType.MODIFIED_DATE,
+                    },
+                    SortingDirection = SortDirection.DESCENDING
+                }
+            },
+        };
+
+        [TestMethod]
+        public async Task TestGetReportDefinitionGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/get-report-definition/all-response-body-properties", requestId.ToString());
+
+            smartsheet.ReportResources.GetReportDefinition(CommonTestConstants.TEST_REPORT_ID);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+            string path = uri.AbsolutePath;
+
+            Assert.AreEqual($"/2.0/reports/{CommonTestConstants.TEST_REPORT_ID}/definition", path);
+            Assert.AreEqual("GET", foundRequest.Method);
+            Assert.AreEqual(string.Empty, uri.Query);
+        }
+
+        [TestMethod]
+        public void TestGetReportDefinitionRequiredResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/get-report-definition/required-response-body-properties", requestId.ToString());
+
+            ReportDefinition result = smartsheet.ReportResources.GetReportDefinition(CommonTestConstants.TEST_REPORT_ID);
+
+            Assert.IsNotNull(result);
+            Assert.IsNull(result.Filters);
+            Assert.IsNull(result.GroupingCriteria);
+            Assert.IsNull(result.SummarizingCriteria);
+            Assert.IsNull(result.SortingCriteria);
+        }
+
+        [TestMethod]
+        public void TestGetReportDefinitionAllResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/get-report-definition/all-response-body-properties", requestId.ToString());
+
+            ReportDefinition result = smartsheet.ReportResources.GetReportDefinition(CommonTestConstants.TEST_REPORT_ID);
+
+            Assert.AreEqual(JsonConvert.SerializeObject(EXPECTED_ALL), JsonConvert.SerializeObject(result));
+        }
+
+        [TestMethod]
+        public void TestGetReportDefinitionError500Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>
+                smartsheet.ReportResources.GetReportDefinition(CommonTestConstants.TEST_REPORT_ID)
+            );
+
+            Assert.IsTrue(exception.Message.Contains("Internal Server Error"));
+        }
+
+        [TestMethod]
+        public void TestGetReportDefinitionError404Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/404-response", requestId.ToString());
+
+            HelperFunctions.AssertRaisesException<SmartsheetException>(
+                () => smartsheet.ReportResources.GetReportDefinition(CommonTestConstants.TEST_REPORT_ID),
+                "Not Found"
+            );
+        }
+
+        [TestMethod]
+        public async Task TestGetReportDefinitionAsyncGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/get-report-definition/all-response-body-properties", requestId.ToString());
+
+            await smartsheet.ReportResources.GetReportDefinitionAsync(CommonTestConstants.TEST_REPORT_ID);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+            string path = uri.AbsolutePath;
+
+            Assert.AreEqual($"/2.0/reports/{CommonTestConstants.TEST_REPORT_ID}/definition", path);
+            Assert.AreEqual("GET", foundRequest.Method);
+            Assert.AreEqual(string.Empty, uri.Query);
+        }
+
+        [TestMethod]
+        public async Task TestGetReportDefinitionAsyncAllResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/get-report-definition/all-response-body-properties", requestId.ToString());
+
+            ReportDefinition result = await smartsheet.ReportResources.GetReportDefinitionAsync(CommonTestConstants.TEST_REPORT_ID);
+
+            Assert.AreEqual(JsonConvert.SerializeObject(EXPECTED_ALL), JsonConvert.SerializeObject(result));
+        }
+
+        [TestMethod]
+        public async Task TestGetReportDefinitionAsyncError500Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+
+            await HelperFunctions.AssertRaisesExceptionAsync<SmartsheetException>(
+                () => smartsheet.ReportResources.GetReportDefinitionAsync(CommonTestConstants.TEST_REPORT_ID),
+                "Internal Server Error");
+        }
+
+        [TestMethod]
+        public async Task TestGetReportDefinitionAsyncError404Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/404-response", requestId.ToString());
+
+            await HelperFunctions.AssertRaisesExceptionAsync<SmartsheetException>(
+                () => smartsheet.ReportResources.GetReportDefinitionAsync(CommonTestConstants.TEST_REPORT_ID),
+                "Not Found");
+        }
+    }
+}

--- a/mock-api-test-sdk-net80/reports/TestGetReportScope.cs
+++ b/mock-api-test-sdk-net80/reports/TestGetReportScope.cs
@@ -1,0 +1,167 @@
+using System.Web;
+using Newtonsoft.Json;
+using Smartsheet.Api;
+using Smartsheet.Api.Models;
+
+namespace mock_api_test_sdk_net80
+{
+    [TestClass]
+    public class TestGetReportScope
+    {
+        private static readonly List<ReportScopeInclusion> EXPECTED_REQUIRED_RESPONSE = new List<ReportScopeInclusion>
+        {
+            new ReportScopeInclusion { AssetType = ReportAssetType.SHEET, AssetId = 2331373580117892 }
+        };
+
+        private static readonly List<ReportScopeInclusion> EXPECTED_ALL_RESPONSE = new List<ReportScopeInclusion>
+        {
+            new ReportScopeInclusion { AssetType = ReportAssetType.SHEET, AssetId = 2331373580117892 },
+            new ReportScopeInclusion { AssetType = ReportAssetType.WORKSPACE, AssetId = 7879278542455688 },
+            new ReportScopeInclusion { AssetType = ReportAssetType.SHEET, AssetId = 1234567890123456 }
+        };
+
+        [TestMethod]
+        public async Task TestGetReportScopeGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/list-report-scope/all-response-body-properties", requestId.ToString());
+
+            smartsheet.ReportResources.GetReportScope(CommonTestConstants.TEST_REPORT_ID);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+
+            Assert.AreEqual($"/2.0/reports/{CommonTestConstants.TEST_REPORT_ID}/scope", uri.AbsolutePath);
+            Assert.AreEqual("GET", foundRequest.Method);
+            Assert.AreEqual(string.Empty, uri.Query);
+        }
+
+        [TestMethod]
+        public async Task TestGetReportScopeWithPaginationParams()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/list-report-scope/all-response-body-properties", requestId.ToString());
+
+            smartsheet.ReportResources.GetReportScope(CommonTestConstants.TEST_REPORT_ID, new TokenPaginationParameters("abc123", 10));
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+            var queryParams = HttpUtility.ParseQueryString(uri.Query);
+
+            Assert.AreEqual("abc123", queryParams["lastKey"]);
+            Assert.AreEqual("10", queryParams["maxItems"]);
+        }
+
+        [TestMethod]
+        public void TestGetReportScopeRequiredResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/list-report-scope/required-response-body-properties", requestId.ToString());
+
+            TokenPaginatedResult<ReportScopeInclusion> result = smartsheet.ReportResources.GetReportScope(CommonTestConstants.TEST_REPORT_ID);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, result.Data.Count);
+            Assert.AreEqual(JsonConvert.SerializeObject(EXPECTED_REQUIRED_RESPONSE), JsonConvert.SerializeObject(result.Data));
+        }
+
+        [TestMethod]
+        public void TestGetReportScopeAllResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/list-report-scope/all-response-body-properties", requestId.ToString());
+
+            TokenPaginatedResult<ReportScopeInclusion> result = smartsheet.ReportResources.GetReportScope(CommonTestConstants.TEST_REPORT_ID);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(3, result.Data.Count);
+            Assert.AreEqual(JsonConvert.SerializeObject(EXPECTED_ALL_RESPONSE), JsonConvert.SerializeObject(result.Data));
+        }
+
+        [TestMethod]
+        public void TestGetReportScopeError500Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>
+                smartsheet.ReportResources.GetReportScope(CommonTestConstants.TEST_REPORT_ID)
+            );
+
+            Assert.IsTrue(exception.Message.Contains("Internal Server Error"));
+        }
+
+        [TestMethod]
+        public void TestGetReportScopeError400Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>
+                smartsheet.ReportResources.GetReportScope(CommonTestConstants.TEST_REPORT_ID)
+            );
+
+            Assert.IsTrue(exception.Message.Contains("Malformed Request"));
+        }
+
+        [TestMethod]
+        public async Task TestGetReportScopeAsyncGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/list-report-scope/all-response-body-properties", requestId.ToString());
+
+            await smartsheet.ReportResources.GetReportScopeAsync(CommonTestConstants.TEST_REPORT_ID);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+
+            Assert.AreEqual($"/2.0/reports/{CommonTestConstants.TEST_REPORT_ID}/scope", uri.AbsolutePath);
+            Assert.AreEqual("GET", foundRequest.Method);
+            Assert.AreEqual(string.Empty, uri.Query);
+        }
+
+        [TestMethod]
+        public async Task TestGetReportScopeAsyncAllResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/list-report-scope/all-response-body-properties", requestId.ToString());
+
+            TokenPaginatedResult<ReportScopeInclusion> result = await smartsheet.ReportResources.GetReportScopeAsync(CommonTestConstants.TEST_REPORT_ID);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(3, result.Data.Count);
+            Assert.AreEqual(JsonConvert.SerializeObject(EXPECTED_ALL_RESPONSE), JsonConvert.SerializeObject(result.Data));
+        }
+
+        [TestMethod]
+        public async Task TestGetReportScopeAsyncError500Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+
+            await HelperFunctions.AssertRaisesExceptionAsync<SmartsheetException>(
+                () => smartsheet.ReportResources.GetReportScopeAsync(CommonTestConstants.TEST_REPORT_ID),
+                "Internal Server Error");
+        }
+
+        [TestMethod]
+        public async Task TestGetReportScopeAsyncError400Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+
+            await HelperFunctions.AssertRaisesExceptionAsync<SmartsheetException>(
+                () => smartsheet.ReportResources.GetReportScopeAsync(CommonTestConstants.TEST_REPORT_ID),
+                "Malformed Request");
+        }
+    }
+}

--- a/mock-api-test-sdk-net80/reports/TestListReportColumns.cs
+++ b/mock-api-test-sdk-net80/reports/TestListReportColumns.cs
@@ -58,6 +58,27 @@ namespace mock_api_test_sdk_net80
         }
 
         [TestMethod]
+        public async Task TestListReportColumnsWithLevelGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/list-report-columns/all-response-body-properties", requestId.ToString());
+
+            smartsheet.ReportResources.ListReportColumns(CommonTestConstants.TEST_REPORT_ID, null, 3);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+            var queryParams = System.Web.HttpUtility.ParseQueryString(uri.Query);
+
+            Assert.AreEqual($"/2.0/reports/{CommonTestConstants.TEST_REPORT_ID}/columns", uri.AbsolutePath);
+            Assert.AreEqual("GET", foundRequest.Method);
+
+            Assert.AreEqual("3", queryParams["level"]);
+        }
+
+        [TestMethod]
         public async Task TestListReportColumnsWithPaginationParams()
         {
             Guid requestId = Guid.NewGuid();

--- a/mock-api-test-sdk-net80/reports/TestListReportColumns.cs
+++ b/mock-api-test-sdk-net80/reports/TestListReportColumns.cs
@@ -1,0 +1,184 @@
+using Newtonsoft.Json;
+using Smartsheet.Api;
+using Smartsheet.Api.Models;
+
+namespace mock_api_test_sdk_net80
+{
+    [TestClass]
+    public class TestListReportColumns
+    {
+        private static readonly List<ReportColumn> EXPECTED_REQUIRED_RESPONSE = new List<ReportColumn>
+        {
+            new ReportColumn { Index = 0, Title = "Task Name", Type = ColumnType.TEXT_NUMBER, Primary = true },
+            new ReportColumn { Index = 1, Type = ColumnType.DATETIME, SystemColumnType = SystemColumnType.CREATED_DATE }
+        };
+
+        private static readonly List<ReportColumn> EXPECTED_ALL_RESPONSE = new List<ReportColumn>
+        {
+            new ReportColumn
+            {
+                VirtualId = 7001L, Index = 0, Title = "Task Name", Type = ColumnType.TEXT_NUMBER,
+                Primary = true, Width = 150, Hidden = false, Validation = true, Version = 0,
+                AutoNumberFormat = new AutoNumberFormat { Fill = "0001", Prefix = "TASK-", StartingNumber = 1, Suffix = "" }
+            },
+            new ReportColumn
+            {
+                VirtualId = 7002L, Index = 1, Title = "Status", Type = ColumnType.PICKLIST,
+                Width = 120, Hidden = false, Validation = false, Version = 0
+            },
+            new ReportColumn
+            {
+                VirtualId = 7003L, Index = 2, Title = "Created By", Type = ColumnType.CONTACT_LIST,
+                SystemColumnType = SystemColumnType.CREATED_BY, Width = 150, Hidden = false, Validation = false, Version = 1
+            },
+            new ReportColumn
+            {
+                VirtualId = 7004L, Index = 3, Title = "Sheet Name", Type = ColumnType.TEXT_NUMBER,
+                SheetNameColumn = true, Width = 200, Hidden = false, Validation = false, Version = 0
+            }
+        };
+
+        [TestMethod]
+        public async Task TestListReportColumnsGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/list-report-columns/all-response-body-properties", requestId.ToString());
+
+            smartsheet.ReportResources.ListReportColumns(CommonTestConstants.TEST_REPORT_ID);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+
+            Assert.AreEqual($"/2.0/reports/{CommonTestConstants.TEST_REPORT_ID}/columns", uri.AbsolutePath);
+            Assert.AreEqual("GET", foundRequest.Method);
+            Assert.AreEqual(string.Empty, uri.Query);
+        }
+
+        [TestMethod]
+        public async Task TestListReportColumnsWithPaginationParams()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/list-report-columns/all-response-body-properties", requestId.ToString());
+
+            smartsheet.ReportResources.ListReportColumns(CommonTestConstants.TEST_REPORT_ID, new TokenPaginationParameters("tok1", 5));
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+            var queryParams = System.Web.HttpUtility.ParseQueryString(uri.Query);
+
+            Assert.AreEqual("tok1", queryParams["lastKey"]);
+            Assert.AreEqual("5", queryParams["maxItems"]);
+        }
+
+        [TestMethod]
+        public void TestListReportColumnsRequiredResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/list-report-columns/required-response-body-properties", requestId.ToString());
+
+            TokenPaginatedResult<ReportColumn> result = smartsheet.ReportResources.ListReportColumns(CommonTestConstants.TEST_REPORT_ID);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(JsonConvert.SerializeObject(EXPECTED_REQUIRED_RESPONSE), JsonConvert.SerializeObject(result.Data));
+        }
+
+        [TestMethod]
+        public void TestListReportColumnsAllResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/list-report-columns/all-response-body-properties", requestId.ToString());
+
+            TokenPaginatedResult<ReportColumn> result = smartsheet.ReportResources.ListReportColumns(CommonTestConstants.TEST_REPORT_ID);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(JsonConvert.SerializeObject(EXPECTED_ALL_RESPONSE), JsonConvert.SerializeObject(result.Data));
+        }
+
+        [TestMethod]
+        public void TestListReportColumnsError500Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>
+                smartsheet.ReportResources.ListReportColumns(CommonTestConstants.TEST_REPORT_ID)
+            );
+
+            Assert.IsTrue(exception.Message.Contains("Internal Server Error"));
+        }
+
+        [TestMethod]
+        public void TestListReportColumnsError400Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>
+                smartsheet.ReportResources.ListReportColumns(CommonTestConstants.TEST_REPORT_ID)
+            );
+
+            Assert.IsTrue(exception.Message.Contains("Malformed Request"));
+        }
+
+        [TestMethod]
+        public async Task TestListReportColumnsAsyncGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/list-report-columns/all-response-body-properties", requestId.ToString());
+
+            await smartsheet.ReportResources.ListReportColumnsAsync(CommonTestConstants.TEST_REPORT_ID);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+
+            Assert.AreEqual($"/2.0/reports/{CommonTestConstants.TEST_REPORT_ID}/columns", uri.AbsolutePath);
+            Assert.AreEqual("GET", foundRequest.Method);
+            Assert.AreEqual(string.Empty, uri.Query);
+        }
+
+        [TestMethod]
+        public async Task TestListReportColumnsAsyncAllResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/list-report-columns/all-response-body-properties", requestId.ToString());
+
+            TokenPaginatedResult<ReportColumn> result = await smartsheet.ReportResources.ListReportColumnsAsync(CommonTestConstants.TEST_REPORT_ID);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(JsonConvert.SerializeObject(EXPECTED_ALL_RESPONSE), JsonConvert.SerializeObject(result.Data));
+        }
+
+        [TestMethod]
+        public async Task TestListReportColumnsAsyncError500Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+
+            await HelperFunctions.AssertRaisesExceptionAsync<SmartsheetException>(
+                () => smartsheet.ReportResources.ListReportColumnsAsync(CommonTestConstants.TEST_REPORT_ID),
+                "Internal Server Error"
+            );
+        }
+
+        [TestMethod]
+        public async Task TestListReportColumnsAsyncError400Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+
+            await HelperFunctions.AssertRaisesExceptionAsync<SmartsheetException>(
+                () => smartsheet.ReportResources.ListReportColumnsAsync(CommonTestConstants.TEST_REPORT_ID),
+                "Malformed Request"
+            );
+        }
+    }
+}

--- a/mock-api-test-sdk-net80/reports/TestUpdateReportColumn.cs
+++ b/mock-api-test-sdk-net80/reports/TestUpdateReportColumn.cs
@@ -1,0 +1,187 @@
+using Newtonsoft.Json;
+using Smartsheet.Api;
+using Smartsheet.Api.Models;
+
+namespace mock_api_test_sdk_net80
+{
+    [TestClass]
+    public class TestUpdateReportColumn
+    {
+        private static readonly UpdateReportColumnRequest REQUEST_REQUIRED = new UpdateReportColumnRequest
+        {
+            Title = "Updated Column",
+            Index = 1
+        };
+
+        private static readonly UpdateReportColumnRequest REQUEST_ALL = new UpdateReportColumnRequest
+        {
+            Title = "Updated Task Name",
+            Index = 2,
+            Hidden = false,
+            Width = 200
+        };
+
+        private static readonly string EXPECTED_REQUIRED_REQUEST_BODY = JsonConvert.SerializeObject(
+            new Dictionary<string, object> { { "title", "Updated Column" }, { "index", 1 } }
+        );
+
+        private static readonly string EXPECTED_ALL_REQUEST_BODY = JsonConvert.SerializeObject(
+            new Dictionary<string, object> { { "title", "Updated Task Name" }, { "index", 2 }, { "hidden", false }, { "width", 200 } }
+        );
+
+        private static readonly ReportColumn EXPECTED_REQUIRED_RESPONSE = new ReportColumn
+        {
+            Index = 1,
+            Title = "Updated Column",
+            Type = ColumnType.TEXT_NUMBER,
+            Primary = true
+        };
+
+        private static readonly ReportColumn EXPECTED_ALL_RESPONSE = new ReportColumn
+        {
+            VirtualId = 7001,
+            Index = 2,
+            Title = "Updated Task Name",
+            Type = ColumnType.TEXT_NUMBER,
+            Primary = true,
+            Width = 200,
+            Hidden = false,
+            Validation = true,
+            Version = 0,
+            AutoNumberFormat = new AutoNumberFormat { Fill = "0001", Prefix = "TASK-", StartingNumber = 1, Suffix = "" }
+        };
+
+        [TestMethod]
+        public async Task TestUpdateReportColumnGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/update-report-column/required-response-body-properties", requestId.ToString());
+
+            smartsheet.ReportResources.UpdateReportColumn(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID, REQUEST_REQUIRED);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+
+            Assert.AreEqual($"/2.0/reports/{CommonTestConstants.TEST_REPORT_ID}/columns/{CommonTestConstants.TEST_COLUMN_VIRTUAL_ID}", uri.AbsolutePath);
+            Assert.AreEqual("PUT", foundRequest.Method);
+            Assert.AreEqual(string.Empty, uri.Query);
+        }
+
+        [TestMethod]
+        public async Task TestUpdateReportColumnRequiredResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/update-report-column/required-response-body-properties", requestId.ToString());
+
+            ReportColumn result = smartsheet.ReportResources.UpdateReportColumn(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID, REQUEST_REQUIRED);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.AreEqual(EXPECTED_REQUIRED_REQUEST_BODY, foundRequest.Body);
+            Assert.AreEqual(JsonConvert.SerializeObject(EXPECTED_REQUIRED_RESPONSE), JsonConvert.SerializeObject(result));
+        }
+
+        [TestMethod]
+        public async Task TestUpdateReportColumnAllResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/update-report-column/all-response-body-properties", requestId.ToString());
+
+            ReportColumn result = smartsheet.ReportResources.UpdateReportColumn(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID, REQUEST_ALL);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.AreEqual(EXPECTED_ALL_REQUEST_BODY, foundRequest.Body);
+            Assert.AreEqual(JsonConvert.SerializeObject(EXPECTED_ALL_RESPONSE), JsonConvert.SerializeObject(result));
+        }
+
+        [TestMethod]
+        public void TestUpdateReportColumnError500Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>
+                smartsheet.ReportResources.UpdateReportColumn(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID, REQUEST_REQUIRED)
+            );
+
+            Assert.IsTrue(exception.Message.Contains("Internal Server Error"));
+        }
+
+        [TestMethod]
+        public void TestUpdateReportColumnError400Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(() =>
+                smartsheet.ReportResources.UpdateReportColumn(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID, REQUEST_REQUIRED)
+            );
+
+            Assert.IsTrue(exception.Message.Contains("Malformed Request"));
+        }
+
+        [TestMethod]
+        public async Task TestUpdateReportColumnAsyncGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/update-report-column/required-response-body-properties", requestId.ToString());
+
+            await smartsheet.ReportResources.UpdateReportColumnAsync(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID, REQUEST_REQUIRED);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsNotNull(foundRequest.AbsoluteUrl);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+
+            Assert.AreEqual($"/2.0/reports/{CommonTestConstants.TEST_REPORT_ID}/columns/{CommonTestConstants.TEST_COLUMN_VIRTUAL_ID}", uri.AbsolutePath);
+            Assert.AreEqual("PUT", foundRequest.Method);
+            Assert.AreEqual(string.Empty, uri.Query);
+        }
+
+        [TestMethod]
+        public async Task TestUpdateReportColumnAsyncAllResponseProperties()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/reports/update-report-column/all-response-body-properties", requestId.ToString());
+
+            ReportColumn result = await smartsheet.ReportResources.UpdateReportColumnAsync(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID, REQUEST_ALL);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.AreEqual(EXPECTED_ALL_REQUEST_BODY, foundRequest.Body);
+            Assert.AreEqual(JsonConvert.SerializeObject(EXPECTED_ALL_RESPONSE), JsonConvert.SerializeObject(result));
+        }
+
+        [TestMethod]
+        public async Task TestUpdateReportColumnAsyncError500Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/500-response", requestId.ToString());
+
+            await HelperFunctions.AssertRaisesExceptionAsync<SmartsheetException>(
+                () => smartsheet.ReportResources.UpdateReportColumnAsync(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID, REQUEST_REQUIRED),
+                "Internal Server Error"
+            );
+        }
+
+        [TestMethod]
+        public async Task TestUpdateReportColumnAsyncError400Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("/errors/400-response", requestId.ToString());
+
+            await HelperFunctions.AssertRaisesExceptionAsync<SmartsheetException>(
+                () => smartsheet.ReportResources.UpdateReportColumnAsync(CommonTestConstants.TEST_REPORT_ID, CommonTestConstants.TEST_COLUMN_VIRTUAL_ID, REQUEST_REQUIRED),
+                "Malformed Request"
+            );
+        }
+    }
+}

--- a/mock-api-test-sdk-net80/users/CommonTestConstants.cs
+++ b/mock-api-test-sdk-net80/users/CommonTestConstants.cs
@@ -7,5 +7,6 @@ namespace mock_api_test_sdk_net80
         public const long TEST_SHEET_ID = 9876543210L;
         public const long TEST_WORKSPACE_ID = 1122334455L;
         public const long TEST_REPORT_ID = 2233445566L;
+        public const long TEST_COLUMN_VIRTUAL_ID = 7001L;
     }
 }

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
@@ -550,7 +550,86 @@ namespace Smartsheet.Api.Internal
 
             return (T)obj;
         }
-        
+
+        /// <summary>
+        /// Update a resource using SmartsheetClient REST API, where the request body type
+        /// differs from the response type.
+        ///
+        /// Exceptions:
+        ///   IllegalArgumentException : if any argument is null, or path is an empty string
+        ///   InvalidRequestException : if there is any problem with the REST API request
+        ///   AuthorizationException : if there is any problem with the REST API authorization (access token)
+        ///   ResourceNotFoundException : if the resource cannot be found
+        ///   ServiceUnavailableException : if the REST API service is not available (possibly due to rate limiting)
+        ///   SmartsheetRestException : if any other REST API related error occurred during the operation
+        ///   SmartsheetException : if any other error occurred during the operation
+        /// </summary>
+        /// <typeparam name="S"> the response resource type </typeparam>
+        /// <typeparam name="T"> the request body type </typeparam>
+        /// <param name="path"> the relative path of the resource </param>
+        /// <param name="object"> the object to send as the request body </param>
+        /// <returns> the updated resource </returns>
+        /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
+        protected internal virtual S UpdateResource<S, T>(string path, T @object)
+        {
+            return this.UpdateResourceAsync<S, T>(path, @object).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Asynchronously update a resource using SmartsheetClient REST API, where the request
+        /// body type differs from the response type.
+        ///
+        /// Exceptions:
+        ///   IllegalArgumentException : if any argument is null, or path is an empty string
+        ///   InvalidRequestException : if there is any problem with the REST API request
+        ///   AuthorizationException : if there is any problem with the REST API authorization (access token)
+        ///   ResourceNotFoundException : if the resource cannot be found
+        ///   ServiceUnavailableException : if the REST API service is not available (possibly due to rate limiting)
+        ///   SmartsheetRestException : if any other REST API related error occurred during the operation
+        ///   SmartsheetException : if any other error occurred during the operation
+        /// </summary>
+        /// <typeparam name="S"> the response resource type </typeparam>
+        /// <typeparam name="T"> the request body type </typeparam>
+        /// <param name="path"> the relative path of the resource </param>
+        /// <param name="object"> the object to send as the request body </param>
+        /// <param name="cancellationToken"> the cancellation token </param>
+        /// <returns> the updated resource </returns>
+        /// <exception cref="SmartsheetException"> the SmartsheetClient exception </exception>
+        protected internal virtual async Task<S> UpdateResourceAsync<S, T>(string path, T @object, CancellationToken cancellationToken = default)
+        {
+            Utils.ThrowIfNull(path, @object);
+            Utils.ThrowIfEmpty(path);
+
+            HttpRequest request = null;
+            try
+            {
+                request = CreateHttpRequest(new Uri(smartsheet.BaseURI, path), HttpMethod.PUT);
+            }
+            catch (Exception e)
+            {
+                throw new SmartsheetException(e);
+            }
+
+            request.Entity = serializeToEntity<T>(@object);
+
+            HttpResponse response = await this.smartsheet.HttpClient.RequestAsync(request, cancellationToken).ConfigureAwait(false);
+
+            Object obj = null;
+            switch (response.StatusCode)
+            {
+                case HttpStatusCode.OK:
+                    obj = this.smartsheet.JsonSerializer.deserializeResult<S>(response.Entity.GetContent()).Result;
+                    break;
+                default:
+                    HandleError(response);
+                    break;
+            }
+
+            smartsheet.HttpClient.ReleaseConnection();
+
+            return (S)obj;
+        }
+
         /// <summary>
         /// Partially update a resource using Smartsheet REST API with PATCH method.
         /// 

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/ReportResourcesImpl.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/ReportResourcesImpl.cs
@@ -584,6 +584,7 @@ namespace Smartsheet.Api.Internal
         /// </summary>
         /// <param name="reportId"> the Id of the report </param>
         /// <param name="tokenPaginationParameters"> the token-based pagination parameters (optional) </param>
+        /// <param name="level"> compatibility level </param>
         /// <returns> a token-paginated result of report columns </returns>
         /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
         /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
@@ -591,9 +592,9 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
-        public virtual TokenPaginatedResult<ReportColumn> ListReportColumns(long reportId, TokenPaginationParameters? tokenPaginationParameters = null)
+        public virtual TokenPaginatedResult<ReportColumn> ListReportColumns(long reportId, TokenPaginationParameters? tokenPaginationParameters = null, int? level = null)
         {
-            return this.ListReportColumnsAsync(reportId, tokenPaginationParameters).GetAwaiter().GetResult();
+            return this.ListReportColumnsAsync(reportId, tokenPaginationParameters, level).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -602,6 +603,7 @@ namespace Smartsheet.Api.Internal
         /// </summary>
         /// <param name="reportId"> the Id of the report </param>
         /// <param name="tokenPaginationParameters"> the token-based pagination parameters (optional) </param>
+        /// <param name="level"> compatibility level </param>
         /// <param name="cancellationToken"> the token to monitor for cancellation requests </param>
         /// <returns> a token-paginated result of report columns </returns>
         /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
@@ -610,7 +612,7 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
-        public virtual async Task<TokenPaginatedResult<ReportColumn>> ListReportColumnsAsync(long reportId, TokenPaginationParameters? tokenPaginationParameters = null, CancellationToken cancellationToken = default)
+        public virtual async Task<TokenPaginatedResult<ReportColumn>> ListReportColumnsAsync(long reportId, TokenPaginationParameters? tokenPaginationParameters = null, int? level = null, CancellationToken cancellationToken = default)
         {
             IDictionary<string, string> parameters = new Dictionary<string, string>();
             if (tokenPaginationParameters != null)
@@ -624,6 +626,10 @@ namespace Smartsheet.Api.Internal
                     parameters.Add("maxItems", tokenPaginationParameters.MaxItems.ToString());
                 }
             }
+            if (level != null)
+            {
+                parameters.Add("level", level.ToString());
+            }
 
             return await this.ListResourcesWithTokenWrapperAsync<ReportColumn>(
                 QueryUtil.GenerateUrl("reports/" + reportId + "/columns", parameters), cancellationToken).ConfigureAwait(false);
@@ -635,6 +641,7 @@ namespace Smartsheet.Api.Internal
         /// </summary>
         /// <param name="reportId"> the Id of the report </param>
         /// <param name="columnVirtualId"> the virtual Id of the report column </param>
+        /// <param name="level"> compatibility level </param>
         /// <returns> the report column (note that if there is no such resource, this method will throw
         /// ResourceNotFoundException rather than returning null). </returns>
         /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
@@ -643,9 +650,9 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
-        public virtual ReportColumn GetReportColumn(long reportId, long columnVirtualId)
+        public virtual ReportColumn GetReportColumn(long reportId, long columnVirtualId, int? level = null)
         {
-            return this.GetReportColumnAsync(reportId, columnVirtualId).GetAwaiter().GetResult();
+            return this.GetReportColumnAsync(reportId, columnVirtualId, level).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -654,6 +661,7 @@ namespace Smartsheet.Api.Internal
         /// </summary>
         /// <param name="reportId"> the Id of the report </param>
         /// <param name="columnVirtualId"> the virtual Id of the report column </param>
+        /// <param name="level"> compatibility level </param>
         /// <param name="cancellationToken"> the token to monitor for cancellation requests </param>
         /// <returns> the report column (note that if there is no such resource, this method will throw
         /// ResourceNotFoundException rather than returning null). </returns>
@@ -663,10 +671,16 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
-        public virtual async Task<ReportColumn> GetReportColumnAsync(long reportId, long columnVirtualId, CancellationToken cancellationToken = default)
+        public virtual async Task<ReportColumn> GetReportColumnAsync(long reportId, long columnVirtualId, int? level = null, CancellationToken cancellationToken = default)
         {
+            IDictionary<string, string> parameters = new Dictionary<string, string>();
+            if (level != null)
+            {
+                parameters.Add("level", level.ToString());
+            }
+
             return await this.GetResourceAsync<ReportColumn>(
-                "reports/" + reportId + "/columns/" + columnVirtualId, typeof(ReportColumn), cancellationToken).ConfigureAwait(false);
+                QueryUtil.GenerateUrl("reports/" + reportId + "/columns/" + columnVirtualId, parameters), typeof(ReportColumn), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/ReportResourcesImpl.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/ReportResourcesImpl.cs
@@ -24,6 +24,8 @@ using Smartsheet.Api.Internal.Http;
 using System.Net;
 using Utils = Smartsheet.Api.Internal.Utility.Utility;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Smartsheet.Api.Internal
 {
@@ -523,6 +525,264 @@ namespace Smartsheet.Api.Internal
             smartsheet.HttpClient.ReleaseConnection();
 
             return result;
+        }
+
+        /// <summary>
+        /// <para>Lists the scope (source sheets and workspaces) for the specified report.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{reportId}/scope</para>
+        /// </summary>
+        /// <param name="reportId"> the Id of the report </param>
+        /// <param name="tokenPaginationParameters"> the token-based pagination parameters (optional) </param>
+        /// <returns> a token-paginated result of report scope inclusions </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public virtual TokenPaginatedResult<ReportScopeInclusion> GetReportScope(long reportId, TokenPaginationParameters? tokenPaginationParameters = null)
+        {
+            return this.GetReportScopeAsync(reportId, tokenPaginationParameters).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Lists the scope (source sheets and workspaces) for the specified report.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{reportId}/scope</para>
+        /// </summary>
+        /// <param name="reportId"> the Id of the report </param>
+        /// <param name="tokenPaginationParameters"> the token-based pagination parameters (optional) </param>
+        /// <param name="cancellationToken"> the token to monitor for cancellation requests </param>
+        /// <returns> a token-paginated result of report scope inclusions </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public virtual async Task<TokenPaginatedResult<ReportScopeInclusion>> GetReportScopeAsync(long reportId, TokenPaginationParameters? tokenPaginationParameters = null, CancellationToken cancellationToken = default)
+        {
+            IDictionary<string, string> parameters = new Dictionary<string, string>();
+            if (tokenPaginationParameters != null)
+            {
+                if (tokenPaginationParameters.LastKey != null)
+                {
+                    parameters.Add("lastKey", tokenPaginationParameters.LastKey);
+                }
+                if (tokenPaginationParameters.MaxItems != null)
+                {
+                    parameters.Add("maxItems", tokenPaginationParameters.MaxItems.ToString());
+                }
+            }
+
+            return await this.ListResourcesWithTokenWrapperAsync<ReportScopeInclusion>(
+                QueryUtil.GenerateUrl("reports/" + reportId + "/scope", parameters), cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <para>Lists the columns for the specified report.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{reportId}/columns</para>
+        /// </summary>
+        /// <param name="reportId"> the Id of the report </param>
+        /// <param name="tokenPaginationParameters"> the token-based pagination parameters (optional) </param>
+        /// <returns> a token-paginated result of report columns </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public virtual TokenPaginatedResult<ReportColumn> ListReportColumns(long reportId, TokenPaginationParameters? tokenPaginationParameters = null)
+        {
+            return this.ListReportColumnsAsync(reportId, tokenPaginationParameters).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Lists the columns for the specified report.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{reportId}/columns</para>
+        /// </summary>
+        /// <param name="reportId"> the Id of the report </param>
+        /// <param name="tokenPaginationParameters"> the token-based pagination parameters (optional) </param>
+        /// <param name="cancellationToken"> the token to monitor for cancellation requests </param>
+        /// <returns> a token-paginated result of report columns </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public virtual async Task<TokenPaginatedResult<ReportColumn>> ListReportColumnsAsync(long reportId, TokenPaginationParameters? tokenPaginationParameters = null, CancellationToken cancellationToken = default)
+        {
+            IDictionary<string, string> parameters = new Dictionary<string, string>();
+            if (tokenPaginationParameters != null)
+            {
+                if (tokenPaginationParameters.LastKey != null)
+                {
+                    parameters.Add("lastKey", tokenPaginationParameters.LastKey);
+                }
+                if (tokenPaginationParameters.MaxItems != null)
+                {
+                    parameters.Add("maxItems", tokenPaginationParameters.MaxItems.ToString());
+                }
+            }
+
+            return await this.ListResourcesWithTokenWrapperAsync<ReportColumn>(
+                QueryUtil.GenerateUrl("reports/" + reportId + "/columns", parameters), cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <para>Gets the specified column in the report.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{reportId}/columns/{columnVirtualId}</para>
+        /// </summary>
+        /// <param name="reportId"> the Id of the report </param>
+        /// <param name="columnVirtualId"> the virtual Id of the report column </param>
+        /// <returns> the report column (note that if there is no such resource, this method will throw
+        /// ResourceNotFoundException rather than returning null). </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public virtual ReportColumn GetReportColumn(long reportId, long columnVirtualId)
+        {
+            return this.GetReportColumnAsync(reportId, columnVirtualId).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Gets the specified column in the report.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{reportId}/columns/{columnVirtualId}</para>
+        /// </summary>
+        /// <param name="reportId"> the Id of the report </param>
+        /// <param name="columnVirtualId"> the virtual Id of the report column </param>
+        /// <param name="cancellationToken"> the token to monitor for cancellation requests </param>
+        /// <returns> the report column (note that if there is no such resource, this method will throw
+        /// ResourceNotFoundException rather than returning null). </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public virtual async Task<ReportColumn> GetReportColumnAsync(long reportId, long columnVirtualId, CancellationToken cancellationToken = default)
+        {
+            return await this.GetResourceAsync<ReportColumn>(
+                "reports/" + reportId + "/columns/" + columnVirtualId, typeof(ReportColumn), cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <para>Updates the specified column in the report.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: PUT /reports/{reportId}/columns/{columnVirtualId}</para>
+        /// </summary>
+        /// <param name="reportId"> the Id of the report </param>
+        /// <param name="columnVirtualId"> the virtual Id of the report column </param>
+        /// <param name="request"> the update report column request </param>
+        /// <returns> the updated report column </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public virtual ReportColumn UpdateReportColumn(long reportId, long columnVirtualId, UpdateReportColumnRequest request)
+        {
+            return this.UpdateReportColumnAsync(reportId, columnVirtualId, request).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Updates the specified column in the report.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: PUT /reports/{reportId}/columns/{columnVirtualId}</para>
+        /// </summary>
+        /// <param name="reportId"> the Id of the report </param>
+        /// <param name="columnVirtualId"> the virtual Id of the report column </param>
+        /// <param name="request"> the update report column request </param>
+        /// <param name="cancellationToken"> the token to monitor for cancellation requests </param>
+        /// <returns> the updated report column </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public virtual async Task<ReportColumn> UpdateReportColumnAsync(long reportId, long columnVirtualId, UpdateReportColumnRequest request, CancellationToken cancellationToken = default)
+        {
+            Utils.ThrowIfNull(request);
+
+            return await this.UpdateResourceAsync<ReportColumn, UpdateReportColumnRequest>(
+                "reports/" + reportId + "/columns/" + columnVirtualId, request, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <para>Deletes the specified column from the report.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: DELETE /reports/{reportId}/columns/{columnVirtualId}</para>
+        /// </summary>
+        /// <param name="reportId"> the Id of the report </param>
+        /// <param name="columnVirtualId"> the virtual Id of the report column </param>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public virtual void DeleteReportColumn(long reportId, long columnVirtualId)
+        {
+            this.DeleteReportColumnAsync(reportId, columnVirtualId).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Deletes the specified column from the report.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: DELETE /reports/{reportId}/columns/{columnVirtualId}</para>
+        /// </summary>
+        /// <param name="reportId"> the Id of the report </param>
+        /// <param name="columnVirtualId"> the virtual Id of the report column </param>
+        /// <param name="cancellationToken"> the token to monitor for cancellation requests </param>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public virtual async Task DeleteReportColumnAsync(long reportId, long columnVirtualId, CancellationToken cancellationToken = default)
+        {
+            await this.DeleteResourceAsync<ReportColumn>(
+                "reports/" + reportId + "/columns/" + columnVirtualId, typeof(ReportColumn), cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <para>Gets the definition (filters, grouping, summarizing, and sorting criteria) for the specified report.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{reportId}/definition</para>
+        /// </summary>
+        /// <param name="reportId"> the Id of the report </param>
+        /// <returns> the report definition (note that if there is no such resource, this method will throw
+        /// ResourceNotFoundException rather than returning null). </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public virtual ReportDefinition GetReportDefinition(long reportId)
+        {
+            return this.GetReportDefinitionAsync(reportId).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// <para>Gets the definition (filters, grouping, summarizing, and sorting criteria) for the specified report.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{reportId}/definition</para>
+        /// </summary>
+        /// <param name="reportId"> the Id of the report </param>
+        /// <param name="cancellationToken"> the token to monitor for cancellation requests </param>
+        /// <returns> the report definition (note that if there is no such resource, this method will throw
+        /// ResourceNotFoundException rather than returning null). </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with  the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        public virtual async Task<ReportDefinition> GetReportDefinitionAsync(long reportId, CancellationToken cancellationToken = default)
+        {
+            return await this.GetResourceAsync<ReportDefinition>(
+                "reports/" + reportId + "/definition", typeof(ReportDefinition), cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/UpdateReportColumnRequest.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/UpdateReportColumnRequest.cs
@@ -1,0 +1,37 @@
+//    #[license]
+//    SmartsheetClient SDK for C#
+//    %%
+//    Copyright (C) 2014 SmartsheetClient
+//    %%
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//            http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//    %[license]
+namespace Smartsheet.Api.Models
+{
+    /// <summary>
+    /// Request body for updating a report column.
+    /// </summary>
+    public class UpdateReportColumnRequest
+    {
+        /// <summary>Title of the column.</summary>
+        public string? Title { get; set; }
+
+        /// <summary>Column index or position (zero-based).</summary>
+        public int? Index { get; set; }
+
+        /// <summary>Indicates whether the column is hidden.</summary>
+        public bool? Hidden { get; set; }
+
+        /// <summary>Display width of the column in pixels.</summary>
+        public int? Width { get; set; }
+    }
+}

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/ReportResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/ReportResources.cs
@@ -19,6 +19,8 @@ using System.Collections.Generic;
 using Smartsheet.Api.Models;
 using System.IO;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Smartsheet.Api
 {
@@ -268,5 +270,59 @@ namespace Smartsheet.Api
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
         CreateReportResult CreateReport(CreateReportRequest request);
+
+        /// <summary>
+        /// <para>Lists the scope (source sheets and workspaces) for the specified report.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{reportId}/scope</para>
+        /// </summary>
+        TokenPaginatedResult<ReportScopeInclusion> GetReportScope(long reportId, TokenPaginationParameters? tokenPaginationParameters = null);
+
+        /// <summary>Async version of <see cref="GetReportScope"/>.</summary>
+        Task<TokenPaginatedResult<ReportScopeInclusion>> GetReportScopeAsync(long reportId, TokenPaginationParameters? tokenPaginationParameters = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// <para>Lists the columns for the specified report.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{reportId}/columns</para>
+        /// </summary>
+        TokenPaginatedResult<ReportColumn> ListReportColumns(long reportId, TokenPaginationParameters? tokenPaginationParameters = null);
+
+        /// <summary>Async version of <see cref="ListReportColumns"/>.</summary>
+        Task<TokenPaginatedResult<ReportColumn>> ListReportColumnsAsync(long reportId, TokenPaginationParameters? tokenPaginationParameters = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// <para>Gets the specified column in the report.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{reportId}/columns/{columnVirtualId}</para>
+        /// </summary>
+        ReportColumn GetReportColumn(long reportId, long columnVirtualId);
+
+        /// <summary>Async version of <see cref="GetReportColumn"/>.</summary>
+        Task<ReportColumn> GetReportColumnAsync(long reportId, long columnVirtualId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// <para>Updates the specified column in the report.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: PUT /reports/{reportId}/columns/{columnVirtualId}</para>
+        /// </summary>
+        ReportColumn UpdateReportColumn(long reportId, long columnVirtualId, UpdateReportColumnRequest request);
+
+        /// <summary>Async version of <see cref="UpdateReportColumn"/>.</summary>
+        Task<ReportColumn> UpdateReportColumnAsync(long reportId, long columnVirtualId, UpdateReportColumnRequest request, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// <para>Deletes the specified column from the report.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: DELETE /reports/{reportId}/columns/{columnVirtualId}</para>
+        /// </summary>
+        void DeleteReportColumn(long reportId, long columnVirtualId);
+
+        /// <summary>Async version of <see cref="DeleteReportColumn"/>.</summary>
+        Task DeleteReportColumnAsync(long reportId, long columnVirtualId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// <para>Gets the definition (filters, grouping, summarizing, and sorting criteria) for the specified report.</para>
+        /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{reportId}/definition</para>
+        /// </summary>
+        ReportDefinition GetReportDefinition(long reportId);
+
+        /// <summary>Async version of <see cref="GetReportDefinition"/>.</summary>
+        Task<ReportDefinition> GetReportDefinitionAsync(long reportId, CancellationToken cancellationToken = default);
     }
 }

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/ReportResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/ReportResources.cs
@@ -284,19 +284,19 @@ namespace Smartsheet.Api
         /// <para>Lists the columns for the specified report.</para>
         /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{reportId}/columns</para>
         /// </summary>
-        TokenPaginatedResult<ReportColumn> ListReportColumns(long reportId, TokenPaginationParameters? tokenPaginationParameters = null);
+        TokenPaginatedResult<ReportColumn> ListReportColumns(long reportId, TokenPaginationParameters? tokenPaginationParameters = null, int? level = null);
 
         /// <summary>Async version of <see cref="ListReportColumns"/>.</summary>
-        Task<TokenPaginatedResult<ReportColumn>> ListReportColumnsAsync(long reportId, TokenPaginationParameters? tokenPaginationParameters = null, CancellationToken cancellationToken = default);
+        Task<TokenPaginatedResult<ReportColumn>> ListReportColumnsAsync(long reportId, TokenPaginationParameters? tokenPaginationParameters = null, int? level = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// <para>Gets the specified column in the report.</para>
         /// <para>It mirrors to the following Smartsheet REST API method: GET /reports/{reportId}/columns/{columnVirtualId}</para>
         /// </summary>
-        ReportColumn GetReportColumn(long reportId, long columnVirtualId);
+        ReportColumn GetReportColumn(long reportId, long columnVirtualId, int? level = null);
 
         /// <summary>Async version of <see cref="GetReportColumn"/>.</summary>
-        Task<ReportColumn> GetReportColumnAsync(long reportId, long columnVirtualId, CancellationToken cancellationToken = default);
+        Task<ReportColumn> GetReportColumnAsync(long reportId, long columnVirtualId, int? level = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// <para>Updates the specified column in the report.</para>


### PR DESCRIPTION
# Pull Request

## Summary

Implements 6 report API endpoints (phase 2):

- `GET /reports/{reportId}/scope` — list report scope (`TokenPaginatedResult<ReportScopeInclusion>`)
- `GET /reports/{reportId}/columns` — list report columns (`TokenPaginatedResult<ReportColumn>`)
- `GET /reports/{reportId}/columns/{columnVirtualId}` — get single report column
- `PUT /reports/{reportId}/columns/{columnVirtualId}` — update report column (new `UpdateReportColumnRequest` model; uses `UpdateResource` with `Result`-wrapped response)
- `DELETE /reports/{reportId}/columns/{columnVirtualId}` — delete report column
- `GET /reports/{reportId}/definition` — get report definition

Each endpoint ships with both synchronous and async (`...Async`) variants.

To support the update endpoint (whose request body type differs from its response type), a heterogeneous `UpdateResource<S, T>` / `UpdateResourceAsync<S, T>` overload was added to `AbstractResources`, mirroring the existing `CreateResource<S, T>` pattern. The existing single-type-parameter `UpdateResource<T>` overloads are left intact, so all existing callers are unaffected.

## Checklist

* [x] Read the **[contribution guide](https://github.com/smartsheet/smartsheet-csharp-sdk/blob/mainline/ADVANCED.md)**
* [x] Successfully build your changes locally
* [x] Include a title that clearly describes your changes and references relevant issues / backlog items
* [x] Include a summary of your changes
* [x] Include tests for your changes where possible