### PR TITLE
docs(events): document and deprecate `ObjectId` in favor of `ObjectIdStr` (AUD-907)

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -1851,6 +1851,23 @@ Many events have additional information available as part of the event. That inf
 Dictionary stored in the `AdditionalDetails` property. Information about the additional details provided can be found
 [here.](https://smartsheet.redoc.ly/tag/eventsDescription)
 
+Each event identifies the object it affected. Use the `ObjectIdStr` property, which holds the object
+identifier as a string and supports both numeric and non-numeric identifiers. The older `ObjectId`
+property is deprecated and kept only for backward compatibility: when the identifier is numeric it
+contains the number, and when the identifier is non-numeric it contains `-1` while the real value is
+available in `ObjectIdStr`. New code should read `ObjectIdStr`.
+
+```csharp
+foreach (Event _event in events)
+{
+    // Preferred: works for all identifier types
+    Console.WriteLine(_event.ObjectIdStr);
+
+    // Deprecated: numeric only; returns -1 for non-numeric identifiers
+    // Console.WriteLine(_event.ObjectId);
+}
+```
+
 ```csharp
 class Program
 {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [X.X.X] - Unreleased
 
+### Deprecated
+
+- Deprecated `Event.ObjectId`; use `Event.ObjectIdStr` instead. `ObjectId` is numeric only and returns -1 for non-numeric identifiers. It is not scheduled for removal.
+
 ## [7.1.0] - 2026-06-26
 
 ### Fixed

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Event.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Event.cs
@@ -16,6 +16,7 @@
 //    limitations under the License.
 //    %[license]
 
+using System;
 using System.Collections.Generic;
 
 namespace Smartsheet.Api.Models
@@ -131,9 +132,10 @@ namespace Smartsheet.Api.Models
         }
 
         /// <summary>
-        /// Get the object ID of the object associated with the event
+        /// Get the object ID of the object associated with the event.
         /// </summary>
         /// <returns>the object ID</returns>
+        [Obsolete("Use ObjectIdStr instead. ObjectId is numeric only and returns -1 for non-numeric identifiers. It is not scheduled for removal, but new code should read ObjectIdStr.", false)]
         public object ObjectId
         {
             get { return objectId; }


### PR DESCRIPTION
## Summary
 
Documents the `ObjectIdStr` property on the `Event` model and marks the older numeric `ObjectId` property as deprecated. The `ObjectIdStr` property itself was added to the SDK in #194; this PR adds the user-facing documentation and the deprecation marker.
 
`ObjectIdStr` holds the affected object's identifier as a string and supports both numeric and non-numeric identifiers. The existing numeric `ObjectId` property is deprecated (kept for backward compatibility) — it returns `-1` when the identifier is non-numeric, in which case the real value is only available via `ObjectIdStr`. New code should read `ObjectIdStr`.
 
## Changes
 
- `ADVANCED.md` — add an explanatory paragraph plus a before/after code sample to the Event Reporting section showing `_event.ObjectIdStr` (preferred) vs. `_event.ObjectId` (deprecated).
- `Event.cs` — add `[Obsolete(..., false)]` to the `ObjectId` property pointing developers to `ObjectIdStr`; add `using System;` for the attribute.
- `CHANGELOG.md` — add a `Deprecated` entry under Unreleased.
## Notes for reviewers
 
- This is a **soft** deprecation. The `[Obsolete]` attribute uses `error: false` (warning only), and the message states that `ObjectId` is *not* scheduled for removal — matching the API changelog (Jun-08-2026). Please flag if you'd prefer stronger or weaker language.
- No build impact: the project does not treat warnings as errors, and nothing internal references `Event.ObjectId`, so no new build warnings are introduced.
- Part of AUD-907. Parallel PRs apply the equivalent documentation + deprecation to the Python, JavaScript, and Java SDKs, and a cross-language migration guide is going into `api-docs`.
## Related
 
- Jira: AUD-907
- Code PR: #194 (added the `ObjectIdStr` property)