### PR TITLE
Prepare for release v7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [X.X.X] - Unreleased
 
+## [7.1.0] - 2026-06-26
+
 ### Fixed
 
 - Deprecation related corrections

--- a/smartsheet-csharp-sdk/smartsheet-csharp-sdk-v2.csproj
+++ b/smartsheet-csharp-sdk/smartsheet-csharp-sdk-v2.csproj
@@ -19,7 +19,7 @@
     <Authors>Smartsheet</Authors>
     <Product>smartsheet-csharp-sdk</Product>
     <PackageTags>Smartsheet Collaboration Project Management Excel spreadsheet</PackageTags>
-    <Version>7.0.0</Version>
+    <Version>7.1.0</Version>
     <AssemblyName>smartsheet-csharp-sdk</AssemblyName>
     <RootNamespace>smartsheet-csharp-sdk</RootNamespace>
     <Configuration>Debug</Configuration>


### PR DESCRIPTION
## Summary

Release prep for v7.1.0 (minor — all changes additive). Bumps `<Version>` to 7.1.0 in the `.csproj` and stamps the CHANGELOG `Unreleased` section with `## [7.1.0] - 2026-06-26`.

Released content accumulated on `mainline` since v7.0.0:
- **Added:** GET path endpoints (`GetSheetPath`, `GetReportPath`, `GetSightPath`, `GetFolderPath`) with `GetLeaf<Asset>()` / `GetLeaf<Asset>Path()` helpers; async (`*Async`) counterparts for `SheetResources.RowResources` and `ReportResources`; hardcoded `paginationType=token` for `ListWorkspaces`.
- **Fixed:** Deprecation-related corrections.
- **Changed:** `ListWebhooks` documentation updated for Jun-03-2026 API behavior changes.

## Test plan
- [ ] CI build + tests pass on the release branch