### PR TITLE
Remove SDK_TEST_ACCESS_TOKEN from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,6 @@ jobs:
       with:
         repository: smartsheet/smartsheet-sdk-tests
         path: smartsheet-sdk-tests
-        token: ${{ secrets.SDK_TEST_ACCESS_TOKEN }}
     - name: Setup Mock API
       run: |
         docker compose -f smartsheet-sdk-tests/docker-compose.yml up -d --wait


### PR DESCRIPTION
## Summary

The `Publish Nuget Package` workflow was failing at the **Checkout smartsheet-sdk-tests** step with `Bad credentials`, which blocked the NuGet publish for the v7.1.0 release ([run](https://github.com/smartsheet/smartsheet-csharp-sdk/actions/runs/28230321018)).

The step passed `secrets.SDK_TEST_ACCESS_TOKEN` to `actions/checkout`, but that token is invalid/expired. Since `smartsheet/smartsheet-sdk-tests` is a **public** repo, `actions/checkout` clones it with the default `GITHUB_TOKEN` — no custom token is needed. This also matches `main.yml`, which already checks out the tests repo without a token.

## Changes

- Removed the `token: ${{ secrets.SDK_TEST_ACCESS_TOKEN }}` line from the `Checkout smartsheet-sdk-tests` step in `.github/workflows/publish.yml`.

## Test plan

- [ ] Re-run the publish workflow (via `workflow_dispatch` or a new release) and confirm the tests-repo checkout succeeds and the package publishes.