### PR TITLE
Add release docs and skills

### DIFF
--- a/.claude/skills/releasing-smartsheet-csharp-sdk/SKILL.md
+++ b/.claude/skills/releasing-smartsheet-csharp-sdk/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: releasing-smartsheet-csharp-sdk
+description: Use when cutting a new release of the Smartsheet C# SDK — version bump, changelog, tag, and GitHub Release
+---
+
+# Release
+
+## Overview
+
+Skill for releasing a new version of the Smartsheet C# SDK.
+
+**Full procedure:** Read `RELEASE.md` in the repository root before taking any action. It is the single source of truth for every step, decision rule, and checklist item.
+
+## When to Use
+
+Use when:
+- User asks to cut a release or bump the version
+- It's time to ship accumulated changes from `mainline`
+- A hotfix needs to be published urgently
+
+Do NOT use for:
+- Adding features or fixing bugs (those are separate PRs merged first)
+- Updating CI or tooling without a version change
+
+## Workflow Summary
+
+```
+mainline (green) → decide version → "Prepare for release" PR → merge → GitHub Release (creates tag) → NuGet publish (auto)
+```
+
+Full details for every step are in `RELEASE.md`.
+
+## Confirmation Gates
+
+**Before committing or pushing anything:** confirm the target version and branch name with the user.
+
+**Before instructing the user to click "Publish release":** confirm they are ready — publishing is the point of no return that triggers NuGet publication and cannot be undone.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,108 @@
+# AI Agent Workflows
+
+This repository uses workflow-specific agents to handle different phases of SDK development. Each agent is backed by a detailed skill file that defines the workflow, and this document provides the project-specific context agents need to work effectively in this codebase.
+
+## Available Agents
+
+- **Implementation Agent** - Adding or modifying API endpoints
+- **Review Agent** - Reviewing endpoint implementations before merge
+- **Release Agent** - Cutting a new SDK release (version bump, changelog, tag, GitHub Release)
+
+---
+
+## Implementation Agent
+
+### Purpose
+
+Adding or modifying Smartsheet API endpoints in the C# SDK.
+
+### Skill Reference
+
+**Skill file:** `.claude/skills/implement-api-endpoint/SKILL.md`
+
+### When to Use
+
+Use the Implementation Agent when:
+- User requests endpoint implementation
+- Adding a new API endpoint to the SDK
+- Modifying existing endpoint behavior
+
+Do NOT use for:
+- Bug fixes in existing endpoints (unless spec changed)
+- Refactoring without behavior changes
+- Documentation-only changes
+
+---
+
+## Review Agent
+
+### Purpose
+
+Systematic code review for API endpoint implementations before merge.
+
+### Skill Reference
+
+**Skill file:** `.claude/skills/review-api-endpoint/SKILL.md`
+
+### When to Use
+
+Use the Review Agent when:
+- Reviewing a pull request with endpoint changes
+- Verifying endpoint implementation before merge
+- Quality check before release
+
+Do NOT use for:
+- Non-endpoint code reviews
+- Documentation-only changes
+
+---
+
+## Release Agent
+
+### Purpose
+
+Cutting a new SDK release: determining the correct semver bump, updating the changelog, bumping the version in the `.csproj`, creating the release PR, tagging, and publishing via GitHub Release.
+
+### Skill Reference
+
+**Skill file:** `.claude/skills/releasing-smartsheet-csharp-sdk/SKILL.md`
+
+**Full procedure:** `RELEASE.md` in the repository root — single source of truth for every step, decision rule, and checklist item.
+
+### When to Use
+
+Use the Release Agent when:
+- User asks to cut a release or publish a new version
+- Accumulated changes on `mainline` need to be shipped
+- A hotfix needs to be released urgently
+
+Do NOT use for:
+- Implementing features or fixing bugs (merge those first)
+- CI or tooling changes without a version bump
+
+---
+
+## Project-Specific Context
+
+This section provides shared context that applies to all agents working in this repository.
+
+### Repository Overview
+
+**Name:** Smartsheet C# SDK
+
+**Purpose:** Client library for the Smartsheet REST API, enabling .NET applications to interact with Smartsheet programmatically.
+
+**Build tool:** .NET / MSBuild (`dotnet`)
+
+**Target framework:** .NET 8.0
+
+**Version file:** `smartsheet-csharp-sdk/smartsheet-csharp-sdk-v2.csproj` (`<Version>` field)
+
+### Key Documentation Files
+
+| File | Purpose | When to Read |
+|------|---------|--------------|
+| `README.md` | Installation, basic usage, example code | Getting started |
+| `ADVANCED.md` | SDK architecture and patterns | Implementing endpoints |
+| `TESTING.md` | Test structure and standards | Writing tests |
+| `RELEASE.md` | Release procedure, version bump, changelog, tagging | Cutting a new SDK release |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,59 +1,10 @@
 # AI Agent Workflows
 
-This repository uses workflow-specific agents to handle different phases of SDK development. Each agent is backed by a detailed skill file that defines the workflow, and this document provides the project-specific context agents need to work effectively in this codebase.
+This repository uses workflow-specific agents to handle different phases of SDK development.
 
 ## Available Agents
 
-- **Implementation Agent** - Adding or modifying API endpoints
-- **Review Agent** - Reviewing endpoint implementations before merge
 - **Release Agent** - Cutting a new SDK release (version bump, changelog, tag, GitHub Release)
-
----
-
-## Implementation Agent
-
-### Purpose
-
-Adding or modifying Smartsheet API endpoints in the C# SDK.
-
-### Skill Reference
-
-**Skill file:** `.claude/skills/implement-api-endpoint/SKILL.md`
-
-### When to Use
-
-Use the Implementation Agent when:
-- User requests endpoint implementation
-- Adding a new API endpoint to the SDK
-- Modifying existing endpoint behavior
-
-Do NOT use for:
-- Bug fixes in existing endpoints (unless spec changed)
-- Refactoring without behavior changes
-- Documentation-only changes
-
----
-
-## Review Agent
-
-### Purpose
-
-Systematic code review for API endpoint implementations before merge.
-
-### Skill Reference
-
-**Skill file:** `.claude/skills/review-api-endpoint/SKILL.md`
-
-### When to Use
-
-Use the Review Agent when:
-- Reviewing a pull request with endpoint changes
-- Verifying endpoint implementation before merge
-- Quality check before release
-
-Do NOT use for:
-- Non-endpoint code reviews
-- Documentation-only changes
 
 ---
 
@@ -61,7 +12,7 @@ Do NOT use for:
 
 ### Purpose
 
-Cutting a new SDK release: determining the correct semver bump, updating the changelog, bumping the version in the `.csproj`, creating the release PR, tagging, and publishing via GitHub Release.
+Cutting a new SDK release: determining the correct semver bump, updating the changelog, bumping the version in `smartsheet-csharp-sdk-v2.csproj`, creating the release PR, tagging, and publishing via GitHub Release.
 
 ### Skill Reference
 
@@ -79,30 +30,3 @@ Use the Release Agent when:
 Do NOT use for:
 - Implementing features or fixing bugs (merge those first)
 - CI or tooling changes without a version bump
-
----
-
-## Project-Specific Context
-
-This section provides shared context that applies to all agents working in this repository.
-
-### Repository Overview
-
-**Name:** Smartsheet C# SDK
-
-**Purpose:** Client library for the Smartsheet REST API, enabling .NET applications to interact with Smartsheet programmatically.
-
-**Build tool:** .NET / MSBuild (`dotnet`)
-
-**Target framework:** .NET 8.0
-
-**Version file:** `smartsheet-csharp-sdk/smartsheet-csharp-sdk-v2.csproj` (`<Version>` field)
-
-### Key Documentation Files
-
-| File | Purpose | When to Read |
-|------|---------|--------------|
-| `README.md` | Installation, basic usage, example code | Getting started |
-| `ADVANCED.md` | SDK architecture and patterns | Implementing endpoints |
-| `TESTING.md` | Test structure and standards | Writing tests |
-| `RELEASE.md` | Release procedure, version bump, changelog, tagging | Cutting a new SDK release |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Code Configuration
+
+For workflow-specific agent instructions, see [AGENTS.md](AGENTS.md).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,143 @@
+# Release Procedure
+
+This document is the single source of truth for releasing the Smartsheet C# SDK. Publishing to NuGet is automated via GitHub Actions, but the version bump and changelog update are done by hand.
+
+## Overview
+
+Releases follow [Semantic Versioning](https://semver.org/) and [Keep a Changelog](https://keepachangelog.com/) conventions. Every release consists of:
+
+1. A "Prepare for release" PR that bumps the version and closes out the changelog.
+2. A merged commit on `mainline` published as a GitHub Release (which also creates the tag).
+3. Automated publishing to NuGet triggered by the GitHub Release event.
+
+## Prerequisites
+
+- Write access to the `smartsheet/smartsheet-csharp-sdk` repository.
+- NuGet credentials are not needed locally — publishing uses a `NUGET_TOKEN` stored as a GitHub Actions secret.
+
+## Step-by-Step Process
+
+### 1. Decide the version bump
+
+Review the `## [X.X.X] - Unreleased` section in `CHANGELOG.md` and apply semver rules:
+
+| Change type | Bump |
+| --- | --- |
+| New endpoints, non-breaking additions | `minor` |
+| Bug fixes, dependency updates | `patch` |
+| Breaking API changes, removed types/methods | `major` |
+
+### 2. Create a "Prepare for release" pull request
+
+Open a branch from `mainline` (e.g., `release/v7.2.0`) and make the following changes:
+
+#### a. Update `CHANGELOG.md`
+
+Feature PRs accumulate entries under `## [X.X.X] - Unreleased`. For the release, insert the new versioned header between that placeholder and its content:
+
+```diff
+ ## [X.X.X] - Unreleased
+
++## [7.2.0] - 2026-07-15
++
+ ### Added
+```
+
+The `## [X.X.X] - Unreleased` placeholder header is never removed — it stays at the top of the file permanently so future PRs have somewhere to add entries.
+
+#### b. Update `smartsheet-csharp-sdk/smartsheet-csharp-sdk-v2.csproj`
+
+```diff
+-    <Version>7.1.0</Version>
++    <Version>7.2.0</Version>
+```
+
+#### c. PR title convention
+
+```
+Prepare for release vX.X.X
+```
+
+Example: `Prepare for release v7.2.0`
+
+### 3. Merge the PR
+
+CI must pass before merging. The `main.yml` workflow runs the build and mock API tests.
+
+### 4. Create and publish the GitHub Release
+
+1. Go to **Releases → Draft a new release** in the GitHub UI.
+2. In the **Choose a tag** field, type the new version (e.g. `v7.2.0`) and select **Create new tag on publish**.
+3. Set the title to `v7.2.0`.
+4. Set the description to the changelog entries for this version (copy from `CHANGELOG.md`).
+5. Click **Publish release**.
+
+The tag is created automatically when the release is published — no separate `git tag` step needed.
+
+Publishing the release (not just saving as a draft) triggers two workflows:
+
+- **publish.yml**: restores dependencies, builds, runs mock API tests, packages with `dotnet pack`, and publishes to NuGet using the `NUGET_TOKEN` secret.
+- **docs.yml**: generates DocFX documentation and deploys to GitHub Pages.
+
+### 5. Verify the publish workflow
+
+Go to [Workflow runs](https://github.com/smartsheet/smartsheet-csharp-sdk/actions) and confirm both the `Publish Nuget Package` and docs jobs succeeded.
+
+### 6. Verify on NuGet
+
+```
+https://www.nuget.org/packages/smartsheet-csharp-sdk/7.2.0
+```
+
+The new version should appear shortly after the workflow succeeds. NuGet indexing can take a few minutes.
+
+## Files Changed in Every Release
+
+| File | What changes |
+| --- | --- |
+| `CHANGELOG.md` | New versioned header inserted below the permanent `Unreleased` placeholder |
+| `smartsheet-csharp-sdk/smartsheet-csharp-sdk-v2.csproj` | `<Version>` field bumped |
+
+## Automation
+
+Publishing is fully automated once the GitHub Release is published:
+
+```
+GitHub Release (published) → publish.yml → dotnet pack → dotnet nuget push → NuGet
+                           → docs.yml → DocFX → GitHub Pages
+```
+
+The workflow uses a `NUGET_TOKEN` GitHub Actions secret — no local credentials needed.
+
+## Troubleshooting
+
+**CI fails on the PR**
+
+Check the `main.yml` run for build or mock API test failures.
+
+**Publish workflow fails after the release is published**
+
+The tag and GitHub Release already exist — do not delete them. Instead:
+
+1. Investigate the failure in the Actions log (common cause: expired `NUGET_TOKEN`).
+2. Re-trigger via **Actions → Publish Nuget Package → Run workflow** (the workflow supports `workflow_dispatch`) after fixing the root cause.
+3. If the root cause requires a code fix, cut a patch release instead.
+
+## Rollback
+
+NuGet does not support deleting published versions. If a bad release ships:
+
+1. Publish a patch release immediately with the fix.
+2. Unlist the bad version via the NuGet UI (unlisted versions still exist but are hidden from search and `dotnet add package` without an explicit version pin).
+
+## Checklist
+
+- [ ] Determined correct semver bump
+- [ ] `CHANGELOG.md` versioned header inserted below the permanent `Unreleased` placeholder
+- [ ] `smartsheet-csharp-sdk-v2.csproj` `<Version>` bumped
+- [ ] PR title: `Prepare for release vX.X.X`
+- [ ] CI passes on the PR
+- [ ] PR merged to `mainline`
+- [ ] GitHub Release created: tag `vX.X.X` set to **Create new tag on publish**, description set to changelog entries, **published** (not draft)
+- [ ] `Publish Nuget Package` and docs workflow jobs verified as succeeded
+- [ ] Version confirmed on NuGet: `https://www.nuget.org/packages/smartsheet-csharp-sdk/X.X.X`


### PR DESCRIPTION
## Summary

Add release documentation and AI agent skill definitions for the Smartsheet C# SDK.

## Changes

- **`RELEASE.md`** — Step-by-step release procedure (semver rules, changelog, tagging, GitHub Release)
- **`AGENTS.md`** — AI agent workflow definitions (Release agent) with project context
- **`CLAUDE.md`** — Entry-point config pointing to `AGENTS.md`
- **`.claude/skills/releasing-smartsheet-csharp-sdk/SKILL.md`** — AI skill file for the Release Agent workflow