### PR TITLE
Prepare for release v7.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [X.X.X] - Unreleased
 
+## [7.2.0] - 2026-07-09
+
 ### Added
 - Support for GET /2.0/reports/{reportId}/definition (Get Report Definition) via `ReportResources.GetReportDefinition`
 - Support for GET /2.0/reports/{reportId}/columns (List Report Columns) via `ReportResources.ListReportColumns`

--- a/smartsheet-csharp-sdk/smartsheet-csharp-sdk-v2.csproj
+++ b/smartsheet-csharp-sdk/smartsheet-csharp-sdk-v2.csproj
@@ -19,7 +19,7 @@
     <Authors>Smartsheet</Authors>
     <Product>smartsheet-csharp-sdk</Product>
     <PackageTags>Smartsheet Collaboration Project Management Excel spreadsheet</PackageTags>
-    <Version>7.1.0</Version>
+    <Version>7.2.0</Version>
     <AssemblyName>smartsheet-csharp-sdk</AssemblyName>
     <RootNamespace>smartsheet-csharp-sdk</RootNamespace>
     <Configuration>Debug</Configuration>


### PR DESCRIPTION
Release prep for v7.2.0 (minor — all changes additive). Bumps <Version> to 7.2.0 in the .csproj and stamps the CHANGELOG Unreleased section with ## [7.2.0] - 2026-07-09.

Released content accumulated on mainline since v7.1.0:

Added:
- Support for GET /2.0/reports/{reportId}/definition (Get Report Definition) via `ReportResources.GetReportDefinition`
- Support for GET /2.0/reports/{reportId}/columns (List Report Columns) via `ReportResources.ListReportColumns`
- Support for GET /2.0/reports/{reportId}/columns/{columnVirtualId} (Get Report Column) via `ReportResources.GetReportColumn`
- Support for PUT /2.0/reports/{reportId}/columns/{columnVirtualId} (Update Report Column) via `ReportResources.UpdateReportColumn`
- Support for DELETE /2.0/reports/{reportId}/columns/{columnVirtualId} (Delete Report Column) via `ReportResources.DeleteReportColumn`
- Support for GET /2.0/reports/{reportId}/scope (List Report Scope) via `ReportResources.GetReportScope`

Deprecated:
- Deprecated `Event.ObjectId`; use `Event.ObjectIdStr` instead. `ObjectId` is numeric only and returns -1 for non-numeric identifiers. It is not scheduled for removal.