### PR TITLE
Fix NullReferenceException on empty/body-less error responses (#211)

### DIFF
--- a/mock-api-test-sdk-net80/DefaultHttpClientRetryTests.cs
+++ b/mock-api-test-sdk-net80/DefaultHttpClientRetryTests.cs
@@ -502,6 +502,36 @@ namespace mock_api_test_sdk_net80
             Assert.IsFalse(result, "Should not retry when content-type is XML");
         }
 
+        [TestMethod]
+        public void ShouldRetry_NullEntity_ReturnsFalse()
+        {
+            // Regression for issue #211: a non-retryable status with no response entity must not
+            // throw NullReferenceException when ShouldRetry inspects the (absent) entity.
+            var client = new TestableDefaultHttpClient();
+
+            var response = CreateMockResponse(HttpStatusCode.Unauthorized, null, null);
+            Assert.IsNull(response.Entity, "Precondition: response should have no entity");
+
+            bool result = client.TestShouldRetry(1, 0, response);
+
+            Assert.IsFalse(result, "Should not retry (and not throw) when the response has no entity");
+        }
+
+        [TestMethod]
+        public void ShouldRetry_NullDeserializedError_ReturnsFalse()
+        {
+            // Regression for issue #211: an empty/body-less JSON response deserializes to a null
+            // Error; reading error.ErrorCode must not throw NullReferenceException.
+            var mockSerializer = new MockJsonSerializer((Error)null);
+            var client = new TestableDefaultHttpClient(mockSerializer);
+
+            var response = CreateMockResponse(HttpStatusCode.Unauthorized, "application/json", "");
+
+            bool result = client.TestShouldRetry(1, 0, response);
+
+            Assert.IsFalse(result, "Should not retry (and not throw) when the error deserializes to null");
+        }
+
         #endregion
 
         #region Exception Handling Tests

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/AbstractResources.cs
@@ -1280,8 +1280,10 @@ namespace Smartsheet.Api.Internal
             Api.Models.Error error;
             try
             {
-                error = this.smartsheet.JsonSerializer.deserialize<Api.Models.Error>(
-                    response.Entity.GetContent());
+                error = response.Entity == null
+                    ? null
+                    : this.smartsheet.JsonSerializer.deserialize<Api.Models.Error>(
+                        response.Entity.GetContent());
             }
             catch (JsonSerializationException ex)
             {
@@ -1294,6 +1296,16 @@ namespace Smartsheet.Api.Internal
             catch (IOException ex)
             {
                 throw new SmartsheetException(ex);
+            }
+
+            // A body-less or non-JSON error response yields no Error; synthesize one so the
+            // status code still maps to a meaningful typed exception instead of an NRE.
+            if (error == null)
+            {
+                error = new Api.Models.Error
+                {
+                    Message = string.Format("HTTP {0} {1} (no response body)", (int)response.StatusCode, response.StatusCode)
+                };
             }
 
             ErrorCode code = ErrorCode.getErrorCode(response.StatusCode);

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Http/DefaultHttpClient.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/Http/DefaultHttpClient.cs
@@ -306,8 +306,15 @@ namespace Smartsheet.Api.Internal.Http
                     {
                         //JSON deserialize the exception we want from the Restsharp response.
                         //Once we get this we can throw it up and make sure to pass it along from an inner exception inside an aggregate exception.
-                        RestResponseContent restResponseContent = this.jsonSerializer.deserialize<RestResponseContent>(restResponse.Content);
-                        throw new SmartsheetException(restResponseContent.message);
+                        RestResponseContent restResponseContent = string.IsNullOrEmpty(restResponse.Content)
+                            ? null
+                            : this.jsonSerializer.deserialize<RestResponseContent>(restResponse.Content);
+                        // A body-less error response deserializes to null; fall back to the status code
+                        // so we still throw a meaningful message instead of a NullReferenceException.
+                        string message = restResponseContent != null && !string.IsNullOrEmpty(restResponseContent.message)
+                            ? restResponseContent.message
+                            : string.Format("HTTP {0} {1}", (int)smartsheetResponse.StatusCode, smartsheetResponse.StatusCode);
+                        throw new SmartsheetException(message);
                     }
                     break;
                 }
@@ -419,6 +426,12 @@ namespace Smartsheet.Api.Internal.Http
                     return await RetrySleep(previousAttempts, totalElapsedTime, response.StatusCode, null, cancellationToken).ConfigureAwait(false);
             }
 
+            // A response with no entity carries no retryable error code; don't retry.
+            if (response.Entity == null)
+            {
+                return false;
+            }
+
             string contentType = response.Entity.ContentType;
             if (contentType != null && !contentType.StartsWith("application/json"))
             {
@@ -443,6 +456,12 @@ namespace Smartsheet.Api.Internal.Http
             catch (IOException ex)
             {
                 throw new SmartsheetException(ex);
+            }
+
+            // An empty or non-error body deserializes to null; there's no code to retry on.
+            if (error == null)
+            {
+                return false;
             }
 
             switch (error.ErrorCode)


### PR DESCRIPTION
## Summary

Fixes #211 — `SheetResources.GetSheetAsCSV` (and any call that hits an error response with an empty/body-less payload) threw an uninformative `NullReferenceException` instead of a `SmartsheetException`. Reported when downloading a sheet with a low-privilege token whose request returned an error with no body.

Root cause: several points on the error/retry path assumed the response always carried a deserializable body. For a body-less error, RestSharp reports the content as an empty string (not null), so an `Entity` is created but deserializing it yields a `null` `Error` — and dereferencing that null threw. The confirmed crash was `DefaultHttpClient.ShouldRetryAsync` at `error.ErrorCode`; guarding it surfaced a second crash in `RequestAsync` where an empty body deserialized to a null `RestResponseContent`.

## Changes

- **`DefaultHttpClient.ShouldRetryAsync`** — return `false` (don't retry) when the response has no `Entity`, or when the body deserializes to a `null` `Error`. Retryable status codes (429/502/503) are still handled first, so they're unaffected.
- **`DefaultHttpClient.RequestAsync`** — when a `ResponseStatus.Error` response has empty content, fall back to a `HTTP {code} {status}` message instead of dereferencing a null `RestResponseContent`.
- **`AbstractResources.HandleError`** — when the response has no `Entity`/body, synthesize a fallback `Error` (descriptive message with the status code) so the existing status-code → typed-exception mapping still applies rather than throwing an NRE.
- **`DefaultHttpClientRetryTests`** — added `ShouldRetry_NullEntity_ReturnsFalse` and `ShouldRetry_NullDeserializedError_ReturnsFalse` regression tests.

## Test plan

- [x] New unit tests pass (`ShouldRetry_NullEntity_ReturnsFalse`, `ShouldRetry_NullDeserializedError_ReturnsFalse`)
- [x] Full `mock-api-test-sdk-net80` suite green (390 passed, 0 failed, 1 pre-existing skip) — no regressions on existing 400/404/500 error-path tests
- [x] Reproduced end-to-end against WireMock: `GetSheetAsCSV` on a body-less 401 now raises a `SmartsheetException` (not an NRE), and a subsequent successful call is unaffected

## Notes

- An end-to-end WireMock repro test (`SheetCsvErrorTests.cs`) and its mappings were developed against the `smartsheet-sdk-tests` repo; those mappings must merge there before an integration test can be added here, so it is intentionally not part of this PR.
- Pre-existing, out of scope: on the file-download path the early `ResponseStatus.Error` throw in `RequestAsync` produces a base `SmartsheetException` rather than the typed subclass (e.g. `AuthorizationException`) that `HandleError` would build. Worth a follow-up.