### PR TITLE
Add changelog entry for #211 null reference fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `ChildResourceType` enum 
 - Test cases for a template resource type
 
+### Fixed
+- `NullReferenceException` when the API returns an error response with an empty or body-less payload (e.g. `GetSheetAsCSV` with a low-privilege token); the SDK now raises a `SmartsheetException` instead (#211)
+
 ## [7.2.0] - 2026-07-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Test cases for a template resource type
 
 ### Fixed
-- `NullReferenceException` when the API returns an error response with an empty or body-less payload (e.g. `GetSheetAsCSV` with a low-privilege token); the SDK now raises a `SmartsheetException` instead (#211)
+- `NullReferenceException` when the API returns an error response with an empty or body-less payload (e.g. `GetSheetAsCSV` with a low-privilege token); the SDK now raises a `SmartsheetException` instead. Fixes [#211](https://github.com/smartsheet/smartsheet-csharp-sdk/issues/211)
 
 ## [7.2.0] - 2026-07-09
 


### PR DESCRIPTION
## Summary

Adds the missing changelog entry for the null-reference fix merged in #213. That PR fixed the `NullReferenceException` raised on empty/body-less error responses but did not update `CHANGELOG.md`.

Adds a `### Fixed` item under the `[X.X.X] - Unreleased` section.

## Test plan

- [x] Documentation-only change; no code affected