### PR TITLE
Prepare for release v7.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [X.X.X] - Unreleased
 
+## [7.3.0] - 2026-07-20
+
 ### Added
 - `ChildResourceType` enum 
 - Test cases for a template resource type

--- a/smartsheet-csharp-sdk/smartsheet-csharp-sdk-v2.csproj
+++ b/smartsheet-csharp-sdk/smartsheet-csharp-sdk-v2.csproj
@@ -19,7 +19,7 @@
     <Authors>Smartsheet</Authors>
     <Product>smartsheet-csharp-sdk</Product>
     <PackageTags>Smartsheet Collaboration Project Management Excel spreadsheet</PackageTags>
-    <Version>7.2.0</Version>
+    <Version>7.3.0</Version>
     <AssemblyName>smartsheet-csharp-sdk</AssemblyName>
     <RootNamespace>smartsheet-csharp-sdk</RootNamespace>
     <Configuration>Debug</Configuration>


### PR DESCRIPTION
## Release v7.3.0

Closes out the changelog and bumps the version for the v7.3.0 release. Branched from clean `mainline` per `RELEASE.md`.

### Changed files
- `CHANGELOG.md` — inserted `## [7.3.0] - 2026-07-20` header below the permanent `Unreleased` placeholder
- `smartsheet-csharp-sdk/smartsheet-csharp-sdk-v2.csproj` — `<Version>` bumped `7.2.0` → `7.3.0`

### Changelog (7.3.0)

**Added**
- `ChildResourceType` enum
- Test cases for a template resource type

**Fixed**
- `NullReferenceException` when the API returns an error response with an empty or body-less payload (e.g. `GetSheetAsCSV` with a low-privilege token); the SDK now raises a `SmartsheetException` instead. Fixes #211

### Next steps (per RELEASE.md, done by a human)
- [ ] CI passes on this PR
- [ ] Merge to `mainline`
- [ ] Draft & publish GitHub Release, tag `v7.3.0` (Create new tag on publish), description = changelog entries → triggers NuGet publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)