### PR TITLE
Add proofs support for getSheet and getReport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [X.X.X] - Unreleased
 
+### Added
+- `Proof` model and `ProofType` enum
+- `Proof` property on rows returned by `GetSheet` and `GetReport`
+- `PROOFS` include value for `SheetLevelInclusion` and `ReportInclusion`
+
 ## [7.3.0] - 2026-07-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - `Proof` model and `ProofType` enum
 - `Proof` property on rows returned by `GetSheet` and `GetReport`
-- `PROOFS` include value for `SheetLevelInclusion` and `ReportInclusion`
+- `PROOFS` include value for `SheetLevelInclusion`, `ReportInclusion`, and `RowInclusion`
 
 ## [7.3.0] - 2026-07-20
 

--- a/mock-api-test-sdk-net80/ProofTest.cs
+++ b/mock-api-test-sdk-net80/ProofTest.cs
@@ -1,0 +1,79 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Smartsheet.Api.Internal.Json;
+using Smartsheet.Api.Models;
+using System.IO;
+
+namespace mock_api_test_sdk_net80
+{
+    [TestClass]
+    public class ProofTest
+    {
+        [TestMethod]
+        public void TestProofDeserialization()
+        {
+            // Mirrors the proof object the API returns on a row when include=proofs is set.
+            string json =
+                "{" +
+                "\"id\":456," +
+                "\"originalId\":123," +
+                "\"name\":\"My proof\"," +
+                "\"type\":\"IMAGE\"," +
+                "\"documentType\":\"PNG\"," +
+                "\"proofRequestUrl\":\"https://app.smartsheet.com/proofs/123\"," +
+                "\"version\":2," +
+                "\"isCompleted\":false" +
+                "}";
+
+            var serializer = new JsonNetSerializer();
+
+            Proof proof;
+            using (var memoryStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(json)))
+            {
+                using (var streamReader = new StreamReader(memoryStream))
+                {
+                    proof = serializer.deserialize<Proof>(streamReader);
+                }
+            }
+
+            Assert.AreEqual(456L, proof.Id);
+            Assert.AreEqual("My proof", proof.Name);
+            Assert.AreEqual(123L, proof.OriginalId);
+            Assert.AreEqual(ProofType.IMAGE, proof.Type);
+            Assert.AreEqual("PNG", proof.DocumentType);
+            Assert.AreEqual("https://app.smartsheet.com/proofs/123", proof.ProofRequestUrl);
+            Assert.AreEqual(2, proof.Version);
+            Assert.AreEqual(false, proof.IsCompleted);
+        }
+
+        [TestMethod]
+        public void TestProofSerializationWireNames()
+        {
+            var serializer = new JsonNetSerializer();
+            var proof = new Proof
+            {
+                Type = ProofType.IMAGE,
+                IsCompleted = false
+            };
+
+            string json;
+            using (var memoryStream = new MemoryStream())
+            {
+                using (var streamWriter = new StreamWriter(memoryStream))
+                {
+                    serializer.serialize(proof, streamWriter);
+                    streamWriter.Flush();
+                    memoryStream.Position = 0;
+
+                    using (var streamReader = new StreamReader(memoryStream))
+                    {
+                        json = streamReader.ReadToEnd();
+                    }
+                }
+            }
+
+            // Property Type -> wire "type"; IsCompleted -> wire "isCompleted".
+            Assert.IsTrue(json.Contains("\"type\":\"IMAGE\""));
+            Assert.IsTrue(json.Contains("\"isCompleted\":false"));
+        }
+    }
+}

--- a/mock-api-test-sdk-net80/RowTests.cs
+++ b/mock-api-test-sdk-net80/RowTests.cs
@@ -8,6 +8,27 @@ namespace mock_api_test_sdk_net80
     public class RowTests
     {
         [TestMethod]
+        public void GetRow_Serialization_Proof()
+        {
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient("Serialization - Proof");
+
+            Row row = smartsheet.SheetResources.RowResources.GetRow(
+                1, 2, new List<RowInclusion> { RowInclusion.PROOFS }, null);
+
+            Proof proof = row.Proof;
+            Assert.IsNotNull(proof);
+            Assert.AreEqual(100L, proof.Id);
+            Assert.AreEqual(100L, proof.OriginalId);
+            Assert.AreEqual("Sample Proof Document", proof.Name);
+            Assert.AreEqual(ProofType.IMAGE, proof.Type);
+            Assert.AreEqual("NONE", proof.DocumentType);
+            Assert.AreEqual("https://app.smartsheet.com/b/proofs/sheets/test123/proofs/proof456", proof.ProofRequestUrl);
+            Assert.AreEqual(1, proof.Version);
+            Assert.AreEqual("john.doe@smartsheet.com", proof.LastUpdatedBy.Email);
+            Assert.AreEqual(false, proof.IsCompleted);
+        }
+
+        [TestMethod]
         public void AddRows_AssignValues_String()
         {
             SmartsheetClient smartsheet = HelperFunctions.SetupClient("Add Rows - Assign Values - String");

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/AbstractRow.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/AbstractRow.cs
@@ -108,6 +108,10 @@ namespace Smartsheet.Api.Models
         private string permalink;
 
         /// <summary>
+        /// Represents the Proof for this row. </summary>
+        private Proof proof;
+
+        /// <summary>
         /// Represents the row number. </summary>
         private int? rowNumber;
 
@@ -173,6 +177,16 @@ namespace Smartsheet.Api.Models
         {
             get { return attachments; }
             set { attachments = value; }
+        }
+
+        /// <summary>
+        /// Gets the Proof.
+        /// </summary>
+        /// <returns> the Proof </returns>
+        public Proof Proof
+        {
+            get { return proof; }
+            set { proof = value; }
         }
 
         /// <summary>

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Inclusions/ReportInclusion.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Inclusions/ReportInclusion.cs
@@ -48,6 +48,11 @@ namespace Smartsheet.Api.Models
         OBJECT_VALUE,
 
         /// <summary>
+        /// Includes the proof object containing proof information associated with each row.
+        /// </summary>
+        PROOFS,
+
+        /// <summary>
         /// Adds the report's scope to the response
         /// </summary>
         SCOPE,

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Inclusions/RowInclusion.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Inclusions/RowInclusion.cs
@@ -74,6 +74,11 @@ namespace Smartsheet.Api.Models
         /// <summary>
         /// Includes objectValue attribute on cells containing values.
         /// </summary>
-        OBJECT_VALUE
+        OBJECT_VALUE,
+
+        /// <summary>
+        /// Includes the proof object containing proof information associated with the row.
+        /// </summary>
+        PROOFS
     }
 }

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Inclusions/SheetLevelInclusion.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Inclusions/SheetLevelInclusion.cs
@@ -78,6 +78,11 @@ namespace Smartsheet.Api.Models
         OWNER_INFO,
 
         /// <summary>
+        /// Includes the proof object containing proof information associated with each row.
+        /// </summary>
+        PROOFS,
+
+        /// <summary>
         /// Includes a permalink attribute for each row. A row permalink represents a direct link to the row in the Smartsheet application.
         /// </summary>
         ROW_PERMALINK,

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Proof.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Proof.cs
@@ -1,0 +1,180 @@
+//    #[license]
+//    SmartsheetClient SDK for C#
+//    %%
+//    Copyright (C) 2014 SmartsheetClient
+//    %%
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//            http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//    %[license]
+
+using System;
+using System.Collections.Generic;
+
+namespace Smartsheet.Api.Models
+{
+    /// <summary>
+    /// Represents the Proof object. A proof is a container that holds attachments and comments for review,
+    /// editing, or approval.
+    /// </summary>
+    public class Proof : NamedModel
+    {
+        /// <summary>
+        /// Represents the ID of the original proof version.
+        /// </summary>
+        private long? originalId;
+
+        /// <summary>
+        /// Represents the Type of the proof.
+        /// </summary>
+        private ProofType? type;
+
+        /// <summary>
+        /// Represents the document Type of the proof.
+        /// </summary>
+        private string documentType;
+
+        /// <summary>
+        /// Represents the URL used to request the proof.
+        /// </summary>
+        private string proofRequestUrl;
+
+        /// <summary>
+        /// Represents the version number of the proof.
+        /// </summary>
+        private int? version;
+
+        /// <summary>
+        /// Represents the date and time the proof was last updated.
+        /// </summary>
+        private DateTime? lastUpdatedAt;
+
+        /// <summary>
+        /// User object containing name and email of the user who last updated the proof.
+        /// </summary>
+        private User lastUpdatedBy;
+
+        /// <summary>
+        /// Indicates whether the proof is completed.
+        /// </summary>
+        private bool? isCompleted;
+
+        /// <summary>
+        /// Represents the Attachments associated with the proof.
+        /// </summary>
+        private IList<Attachment> attachments;
+
+        /// <summary>
+        /// Represents the Discussions associated with the proof.
+        /// </summary>
+        private IList<Discussion> discussions;
+
+        /// <summary>
+        /// Gets the ID of the original proof version.
+        /// </summary>
+        /// <returns> the original Id </returns>
+        public long? OriginalId
+        {
+            get { return originalId; }
+            set { originalId = value; }
+        }
+
+        /// <summary>
+        /// Gets the Type of the proof.
+        /// </summary>
+        /// <returns> the proof Type </returns>
+        public ProofType? Type
+        {
+            get { return type; }
+            set { type = value; }
+        }
+
+        /// <summary>
+        /// Gets the document Type of the proof.
+        /// </summary>
+        /// <returns> the document Type </returns>
+        public string DocumentType
+        {
+            get { return documentType; }
+            set { documentType = value; }
+        }
+
+        /// <summary>
+        /// Gets the URL used to request the proof.
+        /// </summary>
+        /// <returns> the proof request URL </returns>
+        public string ProofRequestUrl
+        {
+            get { return proofRequestUrl; }
+            set { proofRequestUrl = value; }
+        }
+
+        /// <summary>
+        /// Gets the version number of the proof.
+        /// </summary>
+        /// <returns> the version </returns>
+        public int? Version
+        {
+            get { return version; }
+            set { version = value; }
+        }
+
+        /// <summary>
+        /// Gets the date and time the proof was last updated.
+        /// </summary>
+        /// <returns> the last updated at timestamp </returns>
+        public DateTime? LastUpdatedAt
+        {
+            get { return lastUpdatedAt; }
+            set { lastUpdatedAt = value; }
+        }
+
+        /// <summary>
+        /// Gets the user who last updated the proof.
+        /// </summary>
+        /// <returns> the last updated by user </returns>
+        public User LastUpdatedBy
+        {
+            get { return lastUpdatedBy; }
+            set { lastUpdatedBy = value; }
+        }
+
+        /// <summary>
+        /// Gets whether the proof is completed.
+        /// </summary>
+        /// <returns> the completed status </returns>
+        public bool? IsCompleted
+        {
+            get { return isCompleted; }
+            set { isCompleted = value; }
+        }
+
+        /// <summary>
+        /// Gets the Attachments associated with the proof.
+        /// </summary>
+        /// <returns> the Attachments </returns>
+        public IList<Attachment> Attachments
+        {
+            get { return attachments; }
+            set { attachments = value; }
+        }
+
+        /// <summary>
+        /// Gets the Discussions associated with the proof.
+        /// </summary>
+        /// <returns> the Discussions </returns>
+        public IList<Discussion> Discussions
+        {
+            get { return discussions; }
+            set { discussions = value; }
+        }
+    }
+}

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/ProofType.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/ProofType.cs
@@ -1,0 +1,47 @@
+//    #[license]
+//    SmartsheetClient SDK for C#
+//    %%
+//    Copyright (C) 2014 SmartsheetClient
+//    %%
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//            http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//    %[license]
+
+namespace Smartsheet.Api.Models
+{
+    /// <summary>
+    /// Represents the Type of a proof.
+    /// </summary>
+    public enum ProofType
+    {
+        /// <summary>
+        /// Document proof type
+        /// </summary>
+        DOCUMENT,
+        /// <summary>
+        /// Image proof type
+        /// </summary>
+        IMAGE,
+        /// <summary>
+        /// Mixed proof type
+        /// </summary>
+        MIXED,
+        /// <summary>
+        /// No proof type
+        /// </summary>
+        NONE,
+        /// <summary>
+        /// Video proof type
+        /// </summary>
+        VIDEO
+    }
+}


### PR DESCRIPTION
Adds `proofs` inclusion support to `GetSheet` and `GetReport`.

## Changes
- New `Proof` model (`Smartsheet.Api.Models.Proof`) and `ProofType` enum (`DOCUMENT, IMAGE, MIXED, NONE, VIDEO`)
- Added a `Proof` property to `AbstractRow`, so it surfaces on both `Row` and `ReportRow`
- Added `PROOFS` include value to `SheetLevelInclusion` and `ReportInclusion`
- Unit tests for `Proof` (deserialization of an API-shaped proof + wire-name serialization)
- CHANGELOG entry under Unreleased

No changes needed to method signatures or query serialization — the new enum value flows through `QueryUtil` and serializes to `proofs` automatically. `ProofType` is a plain enum (serialized as a string by the globally-registered converter).

DEVECO-2197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added row-level `Proof` support, including a new `Proof` model and `ProofType` enum.
  - Added `PROOFS` inclusion options across row, sheet-level, and report-level results so proof details can be returned with rows.
- **Tests**
  - Added unit tests covering proof serialization/deserialization and `GetRow` proof inclusion behavior.
- **Documentation**
  - Updated `CHANGELOG.md` under “Unreleased” to describe the new proof support and inclusion options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->