### PR TITLE
Support include=planName on List User Plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Proof` model and `ProofType` enum
 - `Proof` property on rows returned by `GetSheet` and `GetReport`
 - `PROOFS` include value for `SheetLevelInclusion`, `ReportInclusion`, and `RowInclusion`
-- Support for the `include` query parameter on GET /2.0/users/{userId}/plans (List User Plans) via a new optional `includes` argument on `UserResources.ListUserPlans` and the new `UserPlanInclusion` enum, whose only value is `PLAN_NAMES`
-- `PlanName` property on `UserPlan`, populated when `PLAN_NAMES` is requested
+- Support for the `include` query parameter on GET /2.0/users/{userId}/plans (List User Plans) via a new optional `includes` argument on `UserResources.ListUserPlans` and the new `UserPlanInclusion` enum, whose only value is `PLAN_NAME`
+- `PlanName` property on `UserPlan`, populated when `PLAN_NAME` is requested
 
 ### Fixed
 - `COMMENTER` value for `AccessLevel`, which previously deserialized to `null` on sheets, reports, workspaces, and shares, and could not be used to create or update a share. Fixes [#218](https://github.com/smartsheet/smartsheet-csharp-sdk/issues/218)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Proof` model and `ProofType` enum
 - `Proof` property on rows returned by `GetSheet` and `GetReport`
 - `PROOFS` include value for `SheetLevelInclusion`, `ReportInclusion`, and `RowInclusion`
+- Support for the `include` query parameter on GET /2.0/users/{userId}/plans (List User Plans) via a new optional `includes` argument on `UserResources.ListUserPlans` and the new `UserPlanInclusion` enum, whose only value is `PLAN_NAMES`
+- `PlanName` property on `UserPlan`, populated when `PLAN_NAMES` is requested
 
 ### Fixed
 - `COMMENTER` value for `AccessLevel`, which previously deserialized to `null` on sheets, reports, workspaces, and shares, and could not be used to create or update a share. Fixes [#218](https://github.com/smartsheet/smartsheet-csharp-sdk/issues/218)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Proof` model and `ProofType` enum
 - `Proof` property on rows returned by `GetSheet` and `GetReport`
 - `PROOFS` include value for `SheetLevelInclusion`, `ReportInclusion`, and `RowInclusion`
-- Support for the `include` query parameter on GET /2.0/users/{userId}/plans (List User Plans) via a new optional `includes` argument on `UserResources.ListUserPlans` and the new `UserPlanInclusion` enum, whose only value is `PLAN_NAME`
+- Support for the `include` query parameter on GET /2.0/users/{userId}/plans (List User Plans) via a new optional `include` argument on `UserResources.ListUserPlans` and the new `UserPlanInclusion` enum, whose only value is `PLAN_NAME`
 - `PlanName` property on `UserPlan`, populated when `PLAN_NAME` is requested
 
 ### Fixed

--- a/mock-api-test-sdk-net80/users/TestListUserPlans.cs
+++ b/mock-api-test-sdk-net80/users/TestListUserPlans.cs
@@ -12,7 +12,7 @@ namespace mock_api_test_sdk_net80
         private const SeatType TEST_SEAT_TYPE = SeatType.MEMBER;
         private static readonly DateTime TEST_SEAT_TYPE_LAST_CHANGED_AT = DateTime.Parse("2025-01-01T00:00:00.123456789Z", null, System.Globalization.DateTimeStyles.RoundtripKind);
         private static readonly DateTime TEST_PROVISIONAL_EXPIRATION_DATE = DateTime.Parse("2026-12-13T12:17:52.525696Z", null, System.Globalization.DateTimeStyles.RoundtripKind);
-        private static readonly UserPlanInclusion[] TEST_INCLUDES = new[] { UserPlanInclusion.PLAN_NAMES };
+        private static readonly UserPlanInclusion[] TEST_INCLUDES = new[] { UserPlanInclusion.PLAN_NAME };
         private const string TEST_PLAN_NAME = "Acme Corporation";
 
         [TestMethod]
@@ -33,7 +33,7 @@ namespace mock_api_test_sdk_net80
             Assert.AreEqual(TEST_MAX_ITEMS.ToString(), queryParams["maxItems"]);
             Assert.AreEqual(TEST_LAST_KEY, queryParams["lastKey"]);
             Assert.AreEqual("true", queryParams["displayContributorSeatType"]);
-            Assert.AreEqual("planNames", queryParams["include"]);
+            Assert.AreEqual("planName", queryParams["include"]);
         }
 
         [TestMethod]

--- a/mock-api-test-sdk-net80/users/TestListUserPlans.cs
+++ b/mock-api-test-sdk-net80/users/TestListUserPlans.cs
@@ -12,7 +12,7 @@ namespace mock_api_test_sdk_net80
         private const SeatType TEST_SEAT_TYPE = SeatType.MEMBER;
         private static readonly DateTime TEST_SEAT_TYPE_LAST_CHANGED_AT = DateTime.Parse("2025-01-01T00:00:00.123456789Z", null, System.Globalization.DateTimeStyles.RoundtripKind);
         private static readonly DateTime TEST_PROVISIONAL_EXPIRATION_DATE = DateTime.Parse("2026-12-13T12:17:52.525696Z", null, System.Globalization.DateTimeStyles.RoundtripKind);
-        private static readonly UserPlanInclusion[] TEST_INCLUDES = new[] { UserPlanInclusion.PLAN_NAME };
+        private static readonly UserPlanInclusion[] TEST_INCLUDE = new[] { UserPlanInclusion.PLAN_NAME };
         private const string TEST_PLAN_NAME = "Acme Corporation";
 
         [TestMethod]
@@ -21,7 +21,7 @@ namespace mock_api_test_sdk_net80
             Guid requestId = Guid.NewGuid();
             SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/list-user-plans/all-response-body-properties", requestId.ToString());
             
-            smartsheet.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, TEST_LAST_KEY, TEST_MAX_ITEMS, displayContributorSeatType: true, includes: TEST_INCLUDES);
+            smartsheet.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, TEST_LAST_KEY, TEST_MAX_ITEMS, displayContributorSeatType: true, include: TEST_INCLUDE);
             WiremockHelper wiremockHelper = new WiremockHelper();
             LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
             var uri = new Uri(foundRequest.AbsoluteUrl);
@@ -42,7 +42,7 @@ namespace mock_api_test_sdk_net80
             Guid requestId = Guid.NewGuid();
             SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/list-user-plans/all-response-body-properties", requestId.ToString());
 
-            TokenPaginatedResult<UserPlan> response = smartsheet.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, TEST_LAST_KEY, TEST_MAX_ITEMS, includes: TEST_INCLUDES);
+            TokenPaginatedResult<UserPlan> response = smartsheet.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, TEST_LAST_KEY, TEST_MAX_ITEMS, include: TEST_INCLUDE);
 
             Assert.IsNotNull(response);
             Assert.AreEqual(TEST_LAST_KEY, response.LastKey);

--- a/mock-api-test-sdk-net80/users/TestListUserPlans.cs
+++ b/mock-api-test-sdk-net80/users/TestListUserPlans.cs
@@ -12,6 +12,8 @@ namespace mock_api_test_sdk_net80
         private const SeatType TEST_SEAT_TYPE = SeatType.MEMBER;
         private static readonly DateTime TEST_SEAT_TYPE_LAST_CHANGED_AT = DateTime.Parse("2025-01-01T00:00:00.123456789Z", null, System.Globalization.DateTimeStyles.RoundtripKind);
         private static readonly DateTime TEST_PROVISIONAL_EXPIRATION_DATE = DateTime.Parse("2026-12-13T12:17:52.525696Z", null, System.Globalization.DateTimeStyles.RoundtripKind);
+        private static readonly UserPlanInclusion[] TEST_INCLUDES = new[] { UserPlanInclusion.PLAN_NAMES };
+        private const string TEST_PLAN_NAME = "Acme Corporation";
 
         [TestMethod]
         public async Task TestListUserPlansGeneratedUrlIsCorrect()
@@ -19,7 +21,7 @@ namespace mock_api_test_sdk_net80
             Guid requestId = Guid.NewGuid();
             SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/list-user-plans/all-response-body-properties", requestId.ToString());
             
-            smartsheet.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, TEST_LAST_KEY, TEST_MAX_ITEMS, displayContributorSeatType: true);
+            smartsheet.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, TEST_LAST_KEY, TEST_MAX_ITEMS, displayContributorSeatType: true, includes: TEST_INCLUDES);
             WiremockHelper wiremockHelper = new WiremockHelper();
             LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
             var uri = new Uri(foundRequest.AbsoluteUrl);
@@ -31,6 +33,7 @@ namespace mock_api_test_sdk_net80
             Assert.AreEqual(TEST_MAX_ITEMS.ToString(), queryParams["maxItems"]);
             Assert.AreEqual(TEST_LAST_KEY, queryParams["lastKey"]);
             Assert.AreEqual("true", queryParams["displayContributorSeatType"]);
+            Assert.AreEqual("planNames", queryParams["include"]);
         }
 
         [TestMethod]
@@ -39,7 +42,7 @@ namespace mock_api_test_sdk_net80
             Guid requestId = Guid.NewGuid();
             SmartsheetClient smartsheet = HelperFunctions.SetupClient("/users/list-user-plans/all-response-body-properties", requestId.ToString());
 
-            TokenPaginatedResult<UserPlan> response = smartsheet.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, TEST_LAST_KEY, TEST_MAX_ITEMS);
+            TokenPaginatedResult<UserPlan> response = smartsheet.UserResources.ListUserPlans(CommonTestConstants.TEST_USER_ID, TEST_LAST_KEY, TEST_MAX_ITEMS, includes: TEST_INCLUDES);
 
             Assert.IsNotNull(response);
             Assert.AreEqual(TEST_LAST_KEY, response.LastKey);
@@ -47,12 +50,14 @@ namespace mock_api_test_sdk_net80
 
             // Verify first plan (MEMBER)
             Assert.AreEqual(CommonTestConstants.TEST_PLAN_ID, response.Data[0].PlanId);
+            Assert.AreEqual(TEST_PLAN_NAME, response.Data[0].PlanName);
             Assert.AreEqual(TEST_SEAT_TYPE, response.Data[0].SeatType);
             Assert.AreEqual(TEST_SEAT_TYPE_LAST_CHANGED_AT, response.Data[0].SeatTypeLastChangedAt);
             Assert.AreEqual(TEST_PROVISIONAL_EXPIRATION_DATE, response.Data[0].ProvisionalExpirationDate);
             Assert.IsFalse(response.Data[0].IsInternal);
 
-            // Verify second plan (CONTRIBUTOR)
+            // Verify second plan (CONTRIBUTOR), which omits the optional plan name
+            Assert.IsNull(response.Data[1].PlanName);
             Assert.AreEqual(SeatType.CONTRIBUTOR, response.Data[1].SeatType);
             Assert.AreEqual(TEST_SEAT_TYPE_LAST_CHANGED_AT, response.Data[1].SeatTypeLastChangedAt);
             Assert.AreEqual(TEST_PROVISIONAL_EXPIRATION_DATE, response.Data[1].ProvisionalExpirationDate);
@@ -69,6 +74,7 @@ namespace mock_api_test_sdk_net80
 
             Assert.IsNotNull(response);
             Assert.AreEqual(CommonTestConstants.TEST_PLAN_ID, response.Data[0].PlanId);
+            Assert.IsNull(response.Data[0].PlanName);
             Assert.AreEqual(TEST_SEAT_TYPE, response.Data[0].SeatType);
             Assert.IsNull(response.Data[0].SeatTypeLastChangedAt);
             Assert.IsNull(response.Data[0].ProvisionalExpirationDate);

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/UserResourcesImpl.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/UserResourcesImpl.cs
@@ -264,9 +264,9 @@ namespace Smartsheet.Api.Internal
         /// <param name="maxItems">The maximum number of items to return.</param>
         /// <param name="displayContributorSeatType">if true, VIEWER seat types are returned as CONTRIBUTOR</param>
         /// <param name="includes">
-        /// <para>used to specify the optional objects to include, currently PLAN_NAMES is supported.</para>
+        /// <para>used to specify the optional objects to include, currently PLAN_NAME is supported.</para>
         /// <para>
-        /// When PLAN_NAMES is included, each returned plan carries the name of its owning
+        /// When PLAN_NAME is included, each returned plan carries the name of its owning
         /// organization in <see cref="UserPlan.PlanName"/>. Organization names are cached
         /// server-side for several hours, so a recently renamed organization may briefly
         /// return its previous name.

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/UserResourcesImpl.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/UserResourcesImpl.cs
@@ -263,7 +263,7 @@ namespace Smartsheet.Api.Internal
         /// <param name="lastKey">The last key for pagination.</param>
         /// <param name="maxItems">The maximum number of items to return.</param>
         /// <param name="displayContributorSeatType">if true, VIEWER seat types are returned as CONTRIBUTOR</param>
-        /// <param name="includes">
+        /// <param name="include">
         /// <para>used to specify the optional objects to include, currently PLAN_NAME is supported.</para>
         /// <para>
         /// When PLAN_NAME is included, each returned plan carries the name of its owning
@@ -279,7 +279,7 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="ResourceNotFoundException">If the user cannot be found (404 Not Found).</exception>
         /// <exception cref="ServiceUnavailableException">If the REST API service is not available (possibly due to rate limiting or 500 Internal Server Error).</exception>
         /// <exception cref="SmartsheetException">If there is any other error during the operation.</exception>
-        public virtual TokenPaginatedResult<UserPlan> ListUserPlans(long userId, string? lastKey, long? maxItems, bool? displayContributorSeatType, IEnumerable<UserPlanInclusion>? includes = null)
+        public virtual TokenPaginatedResult<UserPlan> ListUserPlans(long userId, string? lastKey, long? maxItems, bool? displayContributorSeatType, IEnumerable<UserPlanInclusion>? include = null)
         {
             IDictionary<string, string> parameters = new Dictionary<string, string>();
             if (lastKey != null)
@@ -294,9 +294,9 @@ namespace Smartsheet.Api.Internal
             {
                 parameters.Add("displayContributorSeatType", displayContributorSeatType.ToString().ToLower());
             }
-            if (includes != null)
+            if (include != null)
             {
-                parameters.Add("include", QueryUtil.GenerateCommaSeparatedList(includes));
+                parameters.Add("include", QueryUtil.GenerateCommaSeparatedList(include));
             }
             string path = $"users/{userId}/plans" + QueryUtil.GenerateUrl(null, parameters);
 

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/UserResourcesImpl.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/UserResourcesImpl.cs
@@ -263,6 +263,15 @@ namespace Smartsheet.Api.Internal
         /// <param name="lastKey">The last key for pagination.</param>
         /// <param name="maxItems">The maximum number of items to return.</param>
         /// <param name="displayContributorSeatType">if true, VIEWER seat types are returned as CONTRIBUTOR</param>
+        /// <param name="includes">
+        /// <para>used to specify the optional objects to include, currently PLAN_NAMES is supported.</para>
+        /// <para>
+        /// When PLAN_NAMES is included, each returned plan carries the name of its owning
+        /// organization in <see cref="UserPlan.PlanName"/>. Organization names are cached
+        /// server-side for several hours, so a recently renamed organization may briefly
+        /// return its previous name.
+        /// </para>
+        /// </param>
         /// <returns><see cref="TokenPaginatedResult{T}"/> object containing <see cref="UserPlan"/>.</returns>
         /// <exception cref="System.InvalidOperationException">If any argument is null or empty string.</exception>
         /// <exception cref="InvalidRequestException">If there is any problem with the REST API request.</exception>
@@ -270,7 +279,7 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="ResourceNotFoundException">If the user cannot be found (404 Not Found).</exception>
         /// <exception cref="ServiceUnavailableException">If the REST API service is not available (possibly due to rate limiting or 500 Internal Server Error).</exception>
         /// <exception cref="SmartsheetException">If there is any other error during the operation.</exception>
-        public virtual TokenPaginatedResult<UserPlan> ListUserPlans(long userId, string? lastKey, long? maxItems, bool? displayContributorSeatType)
+        public virtual TokenPaginatedResult<UserPlan> ListUserPlans(long userId, string? lastKey, long? maxItems, bool? displayContributorSeatType, IEnumerable<UserPlanInclusion>? includes = null)
         {
             IDictionary<string, string> parameters = new Dictionary<string, string>();
             if (lastKey != null)
@@ -284,6 +293,10 @@ namespace Smartsheet.Api.Internal
             if (displayContributorSeatType != null)
             {
                 parameters.Add("displayContributorSeatType", displayContributorSeatType.ToString().ToLower());
+            }
+            if (includes != null)
+            {
+                parameters.Add("include", QueryUtil.GenerateCommaSeparatedList(includes));
             }
             string path = $"users/{userId}/plans" + QueryUtil.GenerateUrl(null, parameters);
 

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Inclusions/UserPlanInclusion.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Inclusions/UserPlanInclusion.cs
@@ -27,6 +27,6 @@ namespace Smartsheet.Api.Models
         /// Includes the name of the organization that owns each returned plan in
         /// <see cref="UserPlan.PlanName"/>.
         /// </summary>
-        PLAN_NAMES,
+        PLAN_NAME,
     }
 }

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Inclusions/UserPlanInclusion.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Inclusions/UserPlanInclusion.cs
@@ -1,0 +1,32 @@
+//    #[license]
+//    SmartsheetClient SDK for C#
+//    %%
+//    Copyright (C) 2014 SmartsheetClient
+//    %%
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//            http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//    %[license]
+
+namespace Smartsheet.Api.Models
+{
+    /// <summary>
+    /// Represents specific elements to include in a List User Plans response.
+    /// </summary>
+    public enum UserPlanInclusion
+    {
+        /// <summary>
+        /// Includes the name of the organization that owns each returned plan in
+        /// <see cref="UserPlan.PlanName"/>.
+        /// </summary>
+        PLAN_NAMES,
+    }
+}

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/UserPlan.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/UserPlan.cs
@@ -15,7 +15,7 @@ namespace Smartsheet.Api.Models
         /// <summary>
         /// <para>Gets or sets the name of the organization that owns the plan.</para>
         /// <para>
-        /// This is null unless <c>planNames</c> was requested via the <c>include</c> parameter of
+        /// This is null unless <c>planName</c> was requested via the <c>include</c> parameter of
         /// List User Plans, and is also null for a plan whose owning organization has no name.
         /// </para>
         /// </summary>

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/UserPlan.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/UserPlan.cs
@@ -13,6 +13,15 @@ namespace Smartsheet.Api.Models
         public long PlanId { get; set; }
 
         /// <summary>
+        /// <para>Gets or sets the name of the organization that owns the plan.</para>
+        /// <para>
+        /// This is null unless <c>planNames</c> was requested via the <c>include</c> parameter of
+        /// List User Plans, and is also null for a plan whose owning organization has no name.
+        /// </para>
+        /// </summary>
+        public string? PlanName { get; set; }
+
+        /// <summary>
         /// Gets or sets the seat type.
         /// </summary>
         public SeatType SeatType { get; set; }

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/UserResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/UserResources.cs
@@ -144,7 +144,7 @@ namespace Smartsheet.Api
         /// <param name="lastKey">The last key for pagination.</param>
         /// <param name="maxItems">The maximum number of items to return.</param>
         /// <param name="displayContributorSeatType">if true, VIEWER seat types are returned as CONTRIBUTOR</param>
-        /// <param name="includes">
+        /// <param name="include">
         /// <para>used to specify the optional objects to include, currently PLAN_NAME is supported.</para>
         /// <para>
         /// When PLAN_NAME is included, each returned plan carries the name of its owning
@@ -160,7 +160,7 @@ namespace Smartsheet.Api
         /// <exception cref="ResourceNotFoundException">If the user cannot be found (404 Not Found).</exception>
         /// <exception cref="ServiceUnavailableException">If the REST API service is not available (possibly due to rate limiting or 500 Internal Server Error).</exception>
         /// <exception cref="SmartsheetException">If there is any other error during the operation.</exception>
-        TokenPaginatedResult<UserPlan> ListUserPlans(long userId, string? lastKey, long? maxItems, bool? displayContributorSeatType = null, IEnumerable<UserPlanInclusion>? includes = null);
+        TokenPaginatedResult<UserPlan> ListUserPlans(long userId, string? lastKey, long? maxItems, bool? displayContributorSeatType = null, IEnumerable<UserPlanInclusion>? include = null);
 
         /// <summary>
         /// <para>Removes a user from a plan.</para>

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/UserResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/UserResources.cs
@@ -144,6 +144,15 @@ namespace Smartsheet.Api
         /// <param name="lastKey">The last key for pagination.</param>
         /// <param name="maxItems">The maximum number of items to return.</param>
         /// <param name="displayContributorSeatType">if true, VIEWER seat types are returned as CONTRIBUTOR</param>
+        /// <param name="includes">
+        /// <para>used to specify the optional objects to include, currently PLAN_NAMES is supported.</para>
+        /// <para>
+        /// When PLAN_NAMES is included, each returned plan carries the name of its owning
+        /// organization in <see cref="UserPlan.PlanName"/>. Organization names are cached
+        /// server-side for several hours, so a recently renamed organization may briefly
+        /// return its previous name.
+        /// </para>
+        /// </param>
         /// <returns><see cref="TokenPaginatedResult{T}"/> object containing <see cref="UserPlan"/>.</returns>
         /// <exception cref="System.InvalidOperationException">If any argument is null or empty string.</exception>
         /// <exception cref="InvalidRequestException">If there is any problem with the REST API request.</exception>
@@ -151,7 +160,7 @@ namespace Smartsheet.Api
         /// <exception cref="ResourceNotFoundException">If the user cannot be found (404 Not Found).</exception>
         /// <exception cref="ServiceUnavailableException">If the REST API service is not available (possibly due to rate limiting or 500 Internal Server Error).</exception>
         /// <exception cref="SmartsheetException">If there is any other error during the operation.</exception>
-        TokenPaginatedResult<UserPlan> ListUserPlans(long userId, string? lastKey, long? maxItems, bool? displayContributorSeatType = null);
+        TokenPaginatedResult<UserPlan> ListUserPlans(long userId, string? lastKey, long? maxItems, bool? displayContributorSeatType = null, IEnumerable<UserPlanInclusion>? includes = null);
 
         /// <summary>
         /// <para>Removes a user from a plan.</para>

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/UserResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/UserResources.cs
@@ -145,9 +145,9 @@ namespace Smartsheet.Api
         /// <param name="maxItems">The maximum number of items to return.</param>
         /// <param name="displayContributorSeatType">if true, VIEWER seat types are returned as CONTRIBUTOR</param>
         /// <param name="includes">
-        /// <para>used to specify the optional objects to include, currently PLAN_NAMES is supported.</para>
+        /// <para>used to specify the optional objects to include, currently PLAN_NAME is supported.</para>
         /// <para>
-        /// When PLAN_NAMES is included, each returned plan carries the name of its owning
+        /// When PLAN_NAME is included, each returned plan carries the name of its owning
         /// organization in <see cref="UserPlan.PlanName"/>. Organization names are cached
         /// server-side for several hours, so a recently renamed organization may briefly
         /// return its previous name.


### PR DESCRIPTION
## Summary

Adds support for the `include` query parameter on GET /2.0/users/{userId}/plans (List User Plans), whose only accepted value is `planName`, matching the response field it controls. When requested, each returned plan carries the name of the organization that owns it.

## Changes

- `UserResources.ListUserPlans` gains a trailing optional 5th parameter, `IEnumerable<UserPlanInclusion>? includes = null`, on both the interface and `UserResourcesImpl`. Because it is optional and last, existing callers compile and behave unchanged.
- New `UserPlanInclusion` enum with a single value, `PLAN_NAME`.
- New `PlanName` property on `UserPlan` (`string?`).
- CHANGELOG entries under Unreleased.

Omitting the new parameter is byte-identical to today's behavior: the `include` key is only added to the parameter dictionary when `includes != null`, so the generated URL is unchanged and no `include=` is sent.

## Design notes

Two things fell out of existing conventions rather than needing new code:

- The inclusion enum lives in the existing `Inclusions/` folder alongside its siblings (`SheetLevelInclusion`, `ReportInclusion`, `RowInclusion`, etc.), so it is discoverable in the same place as every other include type.
- `QueryUtil.GenerateCommaSeparatedList` is already enum-oriented and lowerCamelCases enum member names, so `PLAN_NAME` serializes to `planName` and multiple values would join with commas for free. No new serialization code, no per-call string literals. Deserialization is likewise automatic: the existing contract resolver maps the wire field `planName` to the Pascal-case `PlanName` property, as it does for the other fields on this model.

`PlanName` is nullable and deliberately so — it is absent when the enrichment is not requested, and also absent for a plan whose owning organization has no name. Both cases deserialize to `null`.

## Note on organization name freshness

Organization names are cached server-side for roughly four hours, so a recently renamed organization may briefly return its previous name. This is inherent to the API and is documented in the XML doc comments on the `includes` parameter rather than worked around client-side.

## Files changed

- `smartsheet-csharp-sdk/main/Smartsheet/Api/UserResources.cs` — interface signature + parameter docs
- `smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/UserResourcesImpl.cs` — implementation signature + `include` parameter wiring
- `smartsheet-csharp-sdk/main/Smartsheet/Api/Models/Inclusions/UserPlanInclusion.cs` — new enum
- `smartsheet-csharp-sdk/main/Smartsheet/Api/Models/UserPlan.cs` — new `PlanName` property
- `mock-api-test-sdk-net80/users/TestListUserPlans.cs` — test coverage
- `CHANGELOG.md` — two Unreleased entries

## Testing

Full mock API suite against local WireMock on port 8082: **399 passed, 1 skipped (`CopySight`, pre-existing), 0 failed** — matching the pre-change baseline.

`TestListUserPlans` (5/5 passing) covers:
- `include=planName` appears as a query parameter when `includes` is supplied
- `PlanName` deserializes to `"Acme Corporation"` on the first plan in the all-properties response
- `PlanName` is `null` on the second plan, which omits the field
- `PlanName` is `null` in the required-properties response

The mock tests read the shared mappings from [smartsheet-sdk-tests](https://github.com/smartsheet/smartsheet-sdk-tests); the `planName` addition to the List User Plans all-properties mapping merged there in smartsheet/smartsheet-sdk-tests#50, so CI on this PR will pick it up from `mainline`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to include organization plan names when listing user plans.
  * Returned plan names are available in user plan details when requested.
  * Plan names remain unavailable when the inclusion option is omitted.
  * Multiple inclusion options can be provided in a list user plans request.

* **Documentation**
  * Documented inclusion options, plan name availability, and potential server-side caching of renamed organization names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
