### PR TITLE
Prepare for release v7.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [X.X.X] - Unreleased
 
+## [7.4.0] - 2026-08-12
+
 ### Added
 - `Proof` model and `ProofType` enum
 - `Proof` property on rows returned by `GetSheet` and `GetReport`

--- a/smartsheet-csharp-sdk/smartsheet-csharp-sdk-v2.csproj
+++ b/smartsheet-csharp-sdk/smartsheet-csharp-sdk-v2.csproj
@@ -19,7 +19,7 @@
     <Authors>Smartsheet</Authors>
     <Product>smartsheet-csharp-sdk</Product>
     <PackageTags>Smartsheet Collaboration Project Management Excel spreadsheet</PackageTags>
-    <Version>7.3.0</Version>
+    <Version>7.4.0</Version>
     <AssemblyName>smartsheet-csharp-sdk</AssemblyName>
     <RootNamespace>smartsheet-csharp-sdk</RootNamespace>
     <Configuration>Debug</Configuration>


### PR DESCRIPTION
Closes out the CHANGELOG for v7.4.0 and bumps `<Version>` in `smartsheet-csharp-sdk/smartsheet-csharp-sdk-v2.csproj`.

Minor bump: the Unreleased section contains non-breaking additions.

### Added
- `Proof` model and `ProofType` enum
- `Proof` property on rows returned by `GetSheet` and `GetReport`
- `PROOFS` include value for `SheetLevelInclusion`, `ReportInclusion`, and `RowInclusion`
- Support for the `include` query parameter on GET /2.0/users/{userId}/plans (List User Plans) via a new optional `include` argument on `UserResources.ListUserPlans` and the new `UserPlanInclusion` enum, whose only value is `PLAN_NAME`
- `PlanName` property on `UserPlan`, populated when `PLAN_NAME` is requested

### Fixed
- `COMMENTER` value for `AccessLevel`, which previously deserialized to `null` on sheets, reports, workspaces, and shares, and could not be used to create or update a share. Fixes [#218](https://github.com/smartsheet/smartsheet-csharp-sdk/issues/218)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SDK package version to 7.4.0.
  * Added a 7.4.0 release entry to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->