### PR TITLE
C# SDK for GET Data Classification Settings API

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
     "sdk": {
-        "version": "8.0.101",
+        "version": "10.0.400",
         "rollForward": "latestFeature"
     }
 }

--- a/mock-api-test-sdk-net80/GovernanceResourcesTest.cs
+++ b/mock-api-test-sdk-net80/GovernanceResourcesTest.cs
@@ -173,18 +173,6 @@ namespace mock_api_test_sdk_net80
         }
 
         [TestMethod]
-        public void TestGetDataClassificationSettingsError404Response()
-        {
-            Guid requestId = Guid.NewGuid();
-            SmartsheetClient smartsheet = HelperFunctions.SetupClient(
-                "/errors/404-response", requestId.ToString());
-
-            ResourceNotFoundException exception = Assert.ThrowsException<ResourceNotFoundException>(
-                () => smartsheet.GovernanceResources.GetDataClassificationSettings(TEST_PLAN_ID));
-            Assert.AreEqual("Not Found", exception.Message);
-        }
-
-        [TestMethod]
         public void TestGetDataClassificationSettingsError500Response()
         {
             Guid requestId = Guid.NewGuid();

--- a/mock-api-test-sdk-net80/GovernanceResourcesTest.cs
+++ b/mock-api-test-sdk-net80/GovernanceResourcesTest.cs
@@ -1,0 +1,199 @@
+using System.Web;
+using Smartsheet.Api;
+using Smartsheet.Api.Models;
+
+namespace mock_api_test_sdk_net80
+{
+    [TestClass]
+    public class GovernanceResourcesTest
+    {
+        private const long TEST_PLAN_ID = 41878788L;
+        private const long TEST_ORG_ID = 1244212L;
+        private const string TEST_GUIDELINES_URL = "https://wiki.example.com/classification-guide";
+        private const string TEST_LABEL_ID = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+        private const string TEST_LABEL_ID_2 = "4aa85f64-5717-4562-b3fc-2c963f66afa7";
+
+        // ── URL construction ──────────────────────────────────────────────────
+
+        [TestMethod]
+        public async Task TestGetDataClassificationSettingsGeneratedUrlIsCorrect()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient(
+                "/governance/get-data-classification-settings/all-response-body-properties",
+                requestId.ToString());
+
+            smartsheet.GovernanceResources.GetDataClassificationSettings(TEST_PLAN_ID);
+
+            WiremockHelper wiremockHelper = new WiremockHelper();
+            LogModel foundRequest = await wiremockHelper.FindWiremockRequestAsync(requestId.ToString());
+
+            Assert.IsNotNull(foundRequest);
+            var uri = new Uri(foundRequest.AbsoluteUrl);
+            Assert.AreEqual("/2.0/governance/data-classification/settings", uri.AbsolutePath);
+            Assert.AreEqual(TEST_PLAN_ID.ToString(), HttpUtility.ParseQueryString(uri.Query)["planId"]);
+        }
+
+        // ── CUSTOM mode — all optional fields ────────────────────────────────
+
+        [TestMethod]
+        public void TestGetDataClassificationSettingsCustomMode()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient(
+                "/governance/get-data-classification-settings/all-response-body-properties",
+                requestId.ToString());
+
+            DataClassificationSettings response =
+                smartsheet.GovernanceResources.GetDataClassificationSettings(TEST_PLAN_ID);
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual(TEST_ORG_ID, response.OrgId);
+            Assert.AreEqual(TEST_PLAN_ID, response.PlanId);
+            Assert.AreEqual(false, response.IsDisabled);
+            Assert.AreEqual(TEST_GUIDELINES_URL, response.GuidelinesUrl);
+            Assert.AreEqual(true, response.AllowManualChange);
+            Assert.AreEqual(2, response.Labels!.Count);
+            Assert.AreEqual(TEST_LABEL_ID, response.Labels[0].Id);
+            Assert.AreEqual("Confidential", response.Labels[0].Name);
+            Assert.AreEqual("Highly sensitive information", response.Labels[0].Description);
+            Assert.AreEqual("#FFE0E3", response.Labels[0].Color);
+            Assert.AreEqual(1, response.Labels[0].SensitivityOrder);
+            Assert.AreEqual(false, response.Labels[0].IsDefault);
+
+            // CUSTOM mode: only labelApprovers — no top-level approvers.
+            Assert.AreEqual("CUSTOM", response.DowngradeApprovalSettings!.Mode);
+            Assert.IsNull(response.DowngradeApprovalSettings.Approvers);
+            Assert.IsNotNull(response.DowngradeApprovalSettings.LabelApprovers);
+            Assert.AreEqual(1, response.DowngradeApprovalSettings.LabelApprovers!.Count);
+            Assert.AreEqual(TEST_LABEL_ID_2, response.DowngradeApprovalSettings.LabelApprovers[0].LabelId);
+            var labelApprovers = response.DowngradeApprovalSettings.LabelApprovers[0].Approvers!;
+            Assert.AreEqual(2, labelApprovers.Count);
+            Assert.AreEqual("USERS", labelApprovers[0].Type);
+            Assert.AreEqual(1, labelApprovers[0].Ids!.Count);
+            Assert.AreEqual("WORKSPACE_ADMINS", labelApprovers[1].Type);
+            Assert.AreEqual(0, labelApprovers[1].Ids!.Count);
+        }
+
+        // ── APPROVAL_NEEDED mode ──────────────────────────────────────────────
+
+        [TestMethod]
+        public void TestGetDataClassificationSettingsApprovalNeededMode()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient(
+                "/governance/get-data-classification-settings/downgrade-approval-mode-approval-needed",
+                requestId.ToString());
+
+            DataClassificationSettings response =
+                smartsheet.GovernanceResources.GetDataClassificationSettings(TEST_PLAN_ID);
+
+            Assert.AreEqual("APPROVAL_NEEDED", response.DowngradeApprovalSettings!.Mode);
+            // APPROVAL_NEEDED: top-level approvers, no labelApprovers.
+            Assert.IsNotNull(response.DowngradeApprovalSettings.Approvers);
+            Assert.AreEqual(2, response.DowngradeApprovalSettings.Approvers!.Count);
+            Assert.AreEqual("GROUPS", response.DowngradeApprovalSettings.Approvers[0].Type);
+            Assert.AreEqual(2, response.DowngradeApprovalSettings.Approvers[0].Ids!.Count);
+            Assert.AreEqual("USERS", response.DowngradeApprovalSettings.Approvers[1].Type);
+            Assert.AreEqual(1, response.DowngradeApprovalSettings.Approvers[1].Ids!.Count);
+            Assert.IsNull(response.DowngradeApprovalSettings.LabelApprovers);
+        }
+
+        // ── NONE mode (required-only fields) ──────────────────────────────────
+
+        [TestMethod]
+        public void TestGetDataClassificationSettingsRequiredFieldsNoneMode()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient(
+                "/governance/get-data-classification-settings/required-response-body-properties",
+                requestId.ToString());
+
+            DataClassificationSettings response =
+                smartsheet.GovernanceResources.GetDataClassificationSettings(TEST_PLAN_ID);
+
+            Assert.AreEqual(TEST_ORG_ID, response.OrgId);
+            Assert.AreEqual(TEST_PLAN_ID, response.PlanId);
+            Assert.AreEqual(false, response.IsDisabled);
+            Assert.IsNull(response.GuidelinesUrl);
+            Assert.IsNull(response.AllowManualChange);
+            Assert.AreEqual(1, response.Labels!.Count);
+            Assert.IsNull(response.Labels[0].Description);
+            Assert.AreEqual("NONE", response.DowngradeApprovalSettings!.Mode);
+            Assert.IsNull(response.DowngradeApprovalSettings.Approvers);
+            Assert.IsNull(response.DowngradeApprovalSettings.LabelApprovers);
+        }
+
+        // ── Disabled plan ──────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void TestGetDataClassificationSettingsDisabledPlan()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient(
+                "/governance/get-data-classification-settings/disabled-plan",
+                requestId.ToString());
+
+            DataClassificationSettings response =
+                smartsheet.GovernanceResources.GetDataClassificationSettings(TEST_PLAN_ID);
+
+            Assert.AreEqual(true, response.IsDisabled);
+            Assert.AreEqual(0, response.Labels!.Count);
+            Assert.IsNull(response.GuidelinesUrl);
+            Assert.IsNull(response.AllowManualChange);
+            Assert.AreEqual("NONE", response.DowngradeApprovalSettings!.Mode);
+            Assert.IsNull(response.DowngradeApprovalSettings.Approvers);
+            Assert.IsNull(response.DowngradeApprovalSettings.LabelApprovers);
+        }
+
+        // ── Error responses ────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void TestGetDataClassificationSettingsError400Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient(
+                "/errors/400-response", requestId.ToString());
+
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(
+                () => smartsheet.GovernanceResources.GetDataClassificationSettings(TEST_PLAN_ID));
+            Assert.AreEqual("Malformed Request", exception.Message);
+        }
+
+        [TestMethod]
+        public void TestGetDataClassificationSettingsError403Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient(
+                "/errors/403-response", requestId.ToString());
+
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(
+                () => smartsheet.GovernanceResources.GetDataClassificationSettings(TEST_PLAN_ID));
+            Assert.AreEqual("You are not authorized to perform this action.", exception.Message);
+        }
+
+        [TestMethod]
+        public void TestGetDataClassificationSettingsError404Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient(
+                "/errors/404-response", requestId.ToString());
+
+            ResourceNotFoundException exception = Assert.ThrowsException<ResourceNotFoundException>(
+                () => smartsheet.GovernanceResources.GetDataClassificationSettings(TEST_PLAN_ID));
+            Assert.AreEqual("Not Found", exception.Message);
+        }
+
+        [TestMethod]
+        public void TestGetDataClassificationSettingsError500Response()
+        {
+            Guid requestId = Guid.NewGuid();
+            SmartsheetClient smartsheet = HelperFunctions.SetupClient(
+                "/errors/500-response", requestId.ToString());
+
+            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(
+                () => smartsheet.GovernanceResources.GetDataClassificationSettings(TEST_PLAN_ID));
+            Assert.AreEqual("Internal Server Error", exception.Message);
+        }
+    }
+}

--- a/mock-api-test-sdk-net80/GovernanceResourcesTest.cs
+++ b/mock-api-test-sdk-net80/GovernanceResourcesTest.cs
@@ -155,7 +155,7 @@ namespace mock_api_test_sdk_net80
             SmartsheetClient smartsheet = HelperFunctions.SetupClient(
                 "/errors/400-response", requestId.ToString());
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(
+            InvalidRequestException exception = Assert.ThrowsException<InvalidRequestException>(
                 () => smartsheet.GovernanceResources.GetDataClassificationSettings(TEST_PLAN_ID));
             Assert.AreEqual("Malformed Request", exception.Message);
         }
@@ -167,7 +167,7 @@ namespace mock_api_test_sdk_net80
             SmartsheetClient smartsheet = HelperFunctions.SetupClient(
                 "/errors/403-response", requestId.ToString());
 
-            SmartsheetException exception = Assert.ThrowsException<SmartsheetException>(
+            AuthorizationException exception = Assert.ThrowsException<AuthorizationException>(
                 () => smartsheet.GovernanceResources.GetDataClassificationSettings(TEST_PLAN_ID));
             Assert.AreEqual("You are not authorized to perform this action.", exception.Message);
         }

--- a/mock-api-test-sdk-net80/mock-api-test-sdk-net80.csproj
+++ b/mock-api-test-sdk-net80/mock-api-test-sdk-net80.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>mock_api_test_sdk_net80</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/GovernanceResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/GovernanceResources.cs
@@ -1,0 +1,24 @@
+using Smartsheet.Api.Models;
+
+namespace Smartsheet.Api
+{
+    /// <summary>
+    /// Interface for governance resources.
+    /// </summary>
+    public interface GovernanceResources
+    {
+        /// <summary>
+        /// Gets the data classification settings for a plan.
+        /// GET /2.0/governance/data-classification/settings?planId={planId}
+        /// </summary>
+        /// <param name="planId"> the plan ID </param>
+        /// <returns> the data classification settings </returns>
+        /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
+        /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
+        /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
+        /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
+        /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
+        /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
+        DataClassificationSettings GetDataClassificationSettings(long planId);
+    }
+}

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/GovernanceResourcesImpl.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/GovernanceResourcesImpl.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using Smartsheet.Api.Models;
+using Smartsheet.Api.Internal.Util;
+
+namespace Smartsheet.Api.Internal
+{
+    /// <summary>
+    /// Implementation of GovernanceResources.
+    /// </summary>
+    public class GovernanceResourcesImpl : AbstractResources, GovernanceResources
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="smartsheet"> the SmartsheetImpl </param>
+        public GovernanceResourcesImpl(SmartsheetImpl smartsheet) : base(smartsheet) { }
+
+        /// <summary>
+        /// Gets the data classification settings for a plan.
+        /// </summary>
+        /// <param name="planId"> the plan ID </param>
+        /// <returns> the data classification settings </returns>
+        public virtual DataClassificationSettings GetDataClassificationSettings(long planId)
+        {
+            IDictionary<string, string> parameters = new Dictionary<string, string>();
+            parameters.Add("planId", planId.ToString());
+            return GetResource<DataClassificationSettings>(
+                "governance/data-classification/settings" + QueryUtil.GenerateUrl(null, parameters),
+                typeof(DataClassificationSettings));
+        }
+    }
+}

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/SmartsheetImpl.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/SmartsheetImpl.cs
@@ -251,6 +251,15 @@ namespace Smartsheet.Api.Internal
         private AssetSharingResources assetSharing;
 
         /// <summary>
+        /// Represents the AtomicReference for governance resources.
+        ///
+        /// It will be initialized in the constructor and will not change afterwards. The underlying value will be initially set
+        /// as null, and will be initialized to non-null the first time it is accessed via corresponding getter, therefore
+        /// effectively the underlying value is lazily created in a thread safe manner.
+        /// </summary>
+        private GovernanceResources governance;
+
+        /// <summary>
         /// static logger 
         /// </summary>
         private static Logger logger = LogManager.GetCurrentClassLogger();
@@ -624,6 +633,19 @@ namespace Smartsheet.Api.Internal
             {
                 Interlocked.CompareExchange<AssetSharingResources>(ref assetSharing, new AssetSharingResourcesImpl(this), null);
                 return assetSharing;
+            }
+        }
+
+        /// <summary>
+        /// Returns the GovernanceResources instance that provides access to governance resources.
+        /// </summary>
+        /// <returns> the governance resources </returns>
+        public virtual GovernanceResources GovernanceResources
+        {
+            get
+            {
+                Interlocked.CompareExchange<GovernanceResources>(ref governance, new GovernanceResourcesImpl(this), null);
+                return governance;
             }
         }
 

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/ApproverEntry.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/ApproverEntry.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace Smartsheet.Api.Models
+{
+    /// <summary>
+    /// Represents a set of approvers (by type and IDs) for downgrade approval settings.
+    /// </summary>
+    public class ApproverEntry
+    {
+        /// <summary>
+        /// Gets or sets the approver type (e.g. "USERS", "GROUPS", "WORKSPACE_ADMINS").
+        /// </summary>
+        public string? Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of approver IDs.
+        /// </summary>
+        public IList<long>? Ids { get; set; }
+    }
+}

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/ClassificationLabel.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/ClassificationLabel.cs
@@ -1,0 +1,38 @@
+namespace Smartsheet.Api.Models
+{
+    /// <summary>
+    /// Represents a single data classification label.
+    /// </summary>
+    public class ClassificationLabel
+    {
+        /// <summary>
+        /// Gets or sets the label ID (UUID string).
+        /// </summary>
+        public string? Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display name of the label.
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the description of the label.
+        /// </summary>
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the hex color code for the label (e.g. "#FFE0E3").
+        /// </summary>
+        public string? Color { get; set; }
+
+        /// <summary>
+        /// Gets or sets the sensitivity order (lower = more sensitive).
+        /// </summary>
+        public int? SensitivityOrder { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether this label is the default classification.
+        /// </summary>
+        public bool? IsDefault { get; set; }
+    }
+}

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/DataClassificationSettings.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/DataClassificationSettings.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+
+namespace Smartsheet.Api.Models
+{
+    /// <summary>
+    /// Represents the data classification settings for a plan.
+    /// Returned by GET /2.0/governance/data-classification/settings?planId={planId}.
+    /// </summary>
+    public class DataClassificationSettings
+    {
+        /// <summary>
+        /// Gets or sets the organization ID.
+        /// </summary>
+        public long? OrgId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the plan ID.
+        /// </summary>
+        public long? PlanId { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether data classification is disabled for this plan.
+        /// </summary>
+        public bool? IsDisabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL to the classification guidelines.
+        /// </summary>
+        public string? GuidelinesUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether users are allowed to manually change their classification.
+        /// </summary>
+        public bool? AllowManualChange { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of classification labels defined for this plan.
+        /// </summary>
+        public IList<ClassificationLabel>? Labels { get; set; }
+
+        /// <summary>
+        /// Gets or sets the downgrade approval settings.
+        /// </summary>
+        public DowngradeApprovalSettings? DowngradeApprovalSettings { get; set; }
+    }
+}

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/DowngradeApprovalSettings.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/DowngradeApprovalSettings.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace Smartsheet.Api.Models
+{
+    /// <summary>
+    /// Represents the downgrade approval settings for a data classification plan.
+    /// </summary>
+    public class DowngradeApprovalSettings
+    {
+        /// <summary>
+        /// Gets or sets the approval mode (e.g. "NONE", "CUSTOM").
+        /// </summary>
+        public string? Mode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the global approver entries.
+        /// </summary>
+        public IList<ApproverEntry>? Approvers { get; set; }
+
+        /// <summary>
+        /// Gets or sets the per-label approver entries.
+        /// </summary>
+        public IList<LabelApproverEntry>? LabelApprovers { get; set; }
+    }
+}

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/LabelApproverEntry.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/LabelApproverEntry.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace Smartsheet.Api.Models
+{
+    /// <summary>
+    /// Associates a classification label with its set of approvers for downgrade.
+    /// </summary>
+    public class LabelApproverEntry
+    {
+        /// <summary>
+        /// Gets or sets the label ID this approver entry applies to.
+        /// </summary>
+        public string? LabelId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of approver entries for this label.
+        /// </summary>
+        public IList<ApproverEntry>? Approvers { get; set; }
+    }
+}

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/SmartsheetClient.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/SmartsheetClient.cs
@@ -159,5 +159,11 @@ namespace Smartsheet.Api
         /// </summary>
         /// <returns> the sharing resources instance </returns>
         AssetSharingResources AssetSharingResources { get; }
+
+        /// <summary>
+        /// <para>Returns the GovernanceResources instance that provides access to governance resources.</para>
+        /// </summary>
+        /// <returns> the governance resources instance </returns>
+        GovernanceResources GovernanceResources { get; }
     }
 }

--- a/smartsheet-csharp-sdk/smartsheet-csharp-sdk-v2.csproj
+++ b/smartsheet-csharp-sdk/smartsheet-csharp-sdk-v2.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>annotations</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
## Summary

  Adds `GovernanceResources` with `GetDataClassificationSettings(long planId)` to support the new `GET /2.0/governance/data-classification/settings?planId=` public API endpoint.

  **New files:**
  - `Api/GovernanceResources.cs` — interface with sync method
  - `Api/Internal/GovernanceResourcesImpl.cs` — calls `GetResource<DataClassificationSettings>` with `QueryUtil.GenerateUrl` for the `planId` query param
  - `Api/Models/DataClassificationSettings.cs`, `ClassificationLabel.cs`, `DowngradeApprovalSettings.cs`, `ApproverEntry.cs`, `LabelApproverEntry.cs` — auto-property DTOs
  - `mock-api-test-sdk-net80/GovernanceResourcesTest.cs` — 9 tests covering URL/query param, all downgrade modes (NONE/APPROVAL_NEEDED/CUSTOM), disabled plan, and 400/403/404/500 errors

  **Modified files:**
  - `Api/SmartsheetClient.cs` — added `GovernanceResources GovernanceResources { get; }`
  - `Api/Internal/SmartsheetImpl.cs` — added lazy-init `GovernanceResources` field via `Interlocked.CompareExchange`
  - `global.json`, `*.csproj` — updated target framework from `net8.0` to `net10.0` to match locally installed SDK

  Depends on: smartsheet/smartsheet-sdk-tests#51 (WireMock mappings)