### PR TITLE
FIND-3495: Surface 5 new search types in C# SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [X.X.X] - Unreleased
 
+### Added
+
+- `SearchObjectType` enum: added 6 new values — `GRID_ROW`, `FORM`, `COLLECTION_TITLE`, `PORTFOLIO_TITLE`, `PROJECT_TITLE`, `SCENARIO_PLAN_TITLE`.
+- `SearchResponse` model for the unified search-service response (`SearchResults`, `TotalCount`, `Workspaces`, `PersonalWorkspaceId`). `SearchResources.Search()` and `SearchResources.SearchSheet()` now return `SearchResponse`.
+- New properties on `SearchResultItem`: `WorkspaceId`, `ContainerId`, `ModifyDateTime`, `PrimaryColumnCellText` (GRID_ROW only), `AttachmentSource` (ATTACHMENT only), `AttachmentDescription` (ATTACHMENT only), `IsTemplate` (SHEET only).
+
 ## [7.4.0] - 2026-08-12
 
 ### Added

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/SearchResourcesImpl.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Internal/SearchResourcesImpl.cs
@@ -25,6 +25,7 @@ namespace Smartsheet.Api.Internal
     using Api.Models;
     using Smartsheet.Api.Internal.Util;
     using SearchResult = Api.Models.SearchResult;
+    using SearchResponse = Api.Models.SearchResponse;
 
     /// <summary>
     /// This is the implementation of the SearchResources.
@@ -57,7 +58,7 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
-        public virtual SearchResult Search(string query)
+        public virtual SearchResponse Search(string query)
         {
             return this.Search(query, null, null, null);
         }
@@ -77,8 +78,8 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
-        public virtual SearchResult Search(string query, IEnumerable<SearchInclusion>? includes,
-            DateTime? modifiedSince, IEnumerable<SearchScope>? scopes) 
+        public virtual SearchResponse Search(string query, IEnumerable<SearchInclusion>? includes,
+            DateTime? modifiedSince, IEnumerable<SearchScope>? scopes)
         {
             IDictionary<string, string> parameters = new Dictionary<string, string>();
 
@@ -95,7 +96,7 @@ namespace Smartsheet.Api.Internal
                 parameters.Add("scopes", QueryUtil.GenerateCommaSeparatedList(scopes));
             }
             parameters.Add("query", query);
-            return this.GetResource<SearchResult>("search" + QueryUtil.GenerateUrl(null, parameters), typeof(SearchResult));
+            return this.GetResource<SearchResponse>("search" + QueryUtil.GenerateUrl(null, parameters), typeof(SearchResponse));
         }
 
         /// <summary>
@@ -111,9 +112,9 @@ namespace Smartsheet.Api.Internal
         /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
-        public virtual SearchResult SearchSheet(long sheetId, string query)
+        public virtual SearchResponse SearchSheet(long sheetId, string query)
         {
-            return this.GetResource<SearchResult>("search/sheets/" + sheetId + "?query=" + Uri.EscapeDataString(query), typeof(SearchResult));
+            return this.GetResource<SearchResponse>("search/sheets/" + sheetId + "?query=" + Uri.EscapeDataString(query), typeof(SearchResponse));
         }
     }
 }

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/SearchObjectType.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/SearchObjectType.cs
@@ -78,6 +78,26 @@ namespace Smartsheet.Api.Models
         /// Workspace search object type.
         /// </summary>
         [EnumMember(Value = "workspace")]
-        WORKSPACE
+        WORKSPACE,
+
+        // New UPPER_SNAKE_CASE values returned by the search-service path
+        /// <summary>Grid row search object type.</summary>
+        [EnumMember(Value = "GRID_ROW")]
+        GRID_ROW,
+        /// <summary>Form search object type.</summary>
+        [EnumMember(Value = "FORM")]
+        FORM,
+        /// <summary>Collection title search object type.</summary>
+        [EnumMember(Value = "COLLECTION_TITLE")]
+        COLLECTION_TITLE,
+        /// <summary>Portfolio title search object type.</summary>
+        [EnumMember(Value = "PORTFOLIO_TITLE")]
+        PORTFOLIO_TITLE,
+        /// <summary>Project title search object type.</summary>
+        [EnumMember(Value = "PROJECT_TITLE")]
+        PROJECT_TITLE,
+        /// <summary>Scenario plan title search object type.</summary>
+        [EnumMember(Value = "SCENARIO_PLAN_TITLE")]
+        SCENARIO_PLAN_TITLE
     }
 }

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/SearchResponse.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/SearchResponse.cs
@@ -1,0 +1,47 @@
+//    #[license]
+//    SmartsheetClient SDK for C#
+//    %%
+//    Copyright (C) 2026 SmartsheetClient
+//    %%
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//            http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//    %[license]
+
+using System.Collections.Generic;
+
+namespace Smartsheet.Api.Models
+{
+    /// <summary>
+    /// Top-level response returned by the search endpoint (unified search-service schema).
+    /// Use <see cref="SearchResultItem.ObjectType"/> to distinguish result types and
+    /// access type-specific fields.
+    /// </summary>
+    public class SearchResponse
+    {
+        private int? totalCount;
+        private IList<SearchResultItem> searchResults;
+        private IList<object> workspaces;
+        private string personalWorkspaceId;
+
+        /// <summary>Number of items returned in <see cref="SearchResults"/>.</summary>
+        public int? TotalCount { get { return totalCount; } set { totalCount = value; } }
+
+        /// <summary>Array of matched search result items.</summary>
+        public IList<SearchResultItem> SearchResults { get { return searchResults; } set { searchResults = value; } }
+
+        /// <summary>Workspaces associated with the results.</summary>
+        public IList<object> Workspaces { get { return workspaces; } set { workspaces = value; } }
+
+        /// <summary>The authenticated user's personal workspace ID, if present in results.</summary>
+        public string PersonalWorkspaceId { get { return personalWorkspaceId; } set { personalWorkspaceId = value; } }
+    }
+}

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/SearchResultItem.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/Models/SearchResultItem.cs
@@ -188,5 +188,36 @@ namespace Smartsheet.Api.Models
             get { return text; }
             set { text = value; }
         }
+
+        // Fields added for the unified search-service response
+
+        private string workspaceId;
+        private string containerId;
+        private long? modifyDateTime;
+        private string primaryColumnCellText;
+        private string attachmentSource;
+        private string attachmentDescription;
+        private bool? isTemplate;
+
+        /// <summary>ID of the workspace containing this result.</summary>
+        public string WorkspaceId { get { return workspaceId; } set { workspaceId = value; } }
+
+        /// <summary>ID of the direct container (sheet or folder) for this result.</summary>
+        public string ContainerId { get { return containerId; } set { containerId = value; } }
+
+        /// <summary>Last-modified timestamp in milliseconds since the Unix epoch (UTC).</summary>
+        public long? ModifyDateTime { get { return modifyDateTime; } set { modifyDateTime = value; } }
+
+        /// <summary>Primary-column cell text. Only populated for GRID_ROW results.</summary>
+        public string PrimaryColumnCellText { get { return primaryColumnCellText; } set { primaryColumnCellText = value; } }
+
+        /// <summary>Object type the attachment belongs to. Only populated for ATTACHMENT results.</summary>
+        public string AttachmentSource { get { return attachmentSource; } set { attachmentSource = value; } }
+
+        /// <summary>User-provided attachment description. Only populated for ATTACHMENT results.</summary>
+        public string AttachmentDescription { get { return attachmentDescription; } set { attachmentDescription = value; } }
+
+        /// <summary>True if this sheet result is a template. Only populated for SHEET results.</summary>
+        public bool? IsTemplate { get { return isTemplate; } set { isTemplate = value; } }
     }
 }

--- a/smartsheet-csharp-sdk/main/Smartsheet/Api/SearchResources.cs
+++ b/smartsheet-csharp-sdk/main/Smartsheet/Api/SearchResources.cs
@@ -22,6 +22,7 @@ namespace Smartsheet.Api
     using System;
     using System.Collections.Generic;
     using SearchResult = Api.Models.SearchResult;
+    using SearchResponse = Api.Models.SearchResponse;
 
     /// <summary>
     /// This interface provides methods to access search resources.
@@ -42,39 +43,41 @@ namespace Smartsheet.Api
         /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
-        SearchResult Search(string query);
+        SearchResponse Search(string query);
 
         /// <summary>
-        /// <para>Searches all sheets that the user can access, for the specified text.</para>
+        /// <para>Searches all content the user can access for the specified text.</para>
         /// <para>Mirrors to the following Smartsheet REST API method: GET /search</para>
+        /// <para>Returns results across 9 object types: GRID_ROW, ATTACHMENT, SHEET, WORKSPACE,
+        /// FORM, COLLECTION_TITLE, PORTFOLIO_TITLE, PROJECT_TITLE, SCENARIO_PLAN_TITLE.</para>
         /// </summary>
         /// <param name="query"> (required): Text with which to perform the search. </param>
         /// <param name="includes">includes enum set of inclusions</param>
         /// <param name="modifiedSince">only return items modified since this date</param>
         /// <param name="scopes">scopes enum set of search filters</param>
-        /// <returns> SearchResult object that contains a maximum of 100 SearchResultems </returns>
+        /// <returns> SearchResponse containing matched items and total count. </returns>
         /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
         /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
         /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
         /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
-        SearchResult Search(string query, IEnumerable<SearchInclusion>? includes = null,
+        SearchResponse Search(string query, IEnumerable<SearchInclusion>? includes = null,
             DateTime? modifiedSince = null, IEnumerable<SearchScope>? scopes = null);
 
         /// <summary>
-        /// <para>Searches a sheet for the specified text.</para>
+        /// <para>Searches within a specific sheet for the specified text.</para>
         /// <para>Mirrors to the following Smartsheet REST API method: GET /search/sheets/{sheetId}</para>
         /// </summary>
         /// <param name="sheetId"> the sheet Id </param>
         /// <param name="query"> the query text </param>
-        /// <returns> SearchResult object that contains a maximum of 100 SearchResultems </returns>
+        /// <returns> SearchResponse containing matched items and total count. </returns>
         /// <exception cref="System.InvalidOperationException"> if any argument is null or an empty string </exception>
         /// <exception cref="InvalidRequestException"> if there is any problem with the REST API request </exception>
         /// <exception cref="AuthorizationException"> if there is any problem with the REST API authorization (access token) </exception>
         /// <exception cref="ResourceNotFoundException"> if the resource cannot be found </exception>
         /// <exception cref="ServiceUnavailableException"> if the REST API service is not available (possibly due to rate limiting) </exception>
         /// <exception cref="SmartsheetException"> if there is any other error during the operation </exception>
-        SearchResult SearchSheet(long sheetId, string query);
+        SearchResponse SearchSheet(long sheetId, string query);
     }
 }


### PR DESCRIPTION
Description:

  Updates the C# SDK to support the 5 new search result types now exposed by the Smartsheet search-service public API: FORM, COLLECTION_TITLE, PORTFOLIO_TITLE, PROJECT_TITLE,
  SCENARIO_PLAN_TITLE.

  Changes:

  - SearchObjectType.cs — added 6 new enum values: GRID_ROW, FORM, COLLECTION_TITLE, PORTFOLIO_TITLE, PROJECT_TITLE, SCENARIO_PLAN_TITLE. Legacy lowercase values are kept for
    backward compatibility.
  - SearchResponse.cs — new model for the unified search-service response (SearchResults, TotalCount, Workspaces, PersonalWorkspaceId).
  - SearchResultItem.cs — added 7 new properties: WorkspaceId, ContainerId, ModifyDateTime, PrimaryColumnCellText (GRID_ROW only), AttachmentSource (ATTACHMENT only),
    AttachmentDescription (ATTACHMENT only), IsTemplate (SHEET only).
  - SearchResources.cs / SearchResourcesImpl.cs — Search() and SearchSheet() now return SearchResponse.
  - CHANGELOG.md — entry under [X.X.X] - Unreleased.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded search results to support additional object types, including rows, forms, collections, portfolios, projects, and scenario plans.
  * Added unified search response details, including total results, workspaces, personal workspace information, and richer result metadata.
  * Updated search operations to return the enhanced response format.
* **Documentation**
  * Expanded search documentation with supported object types and response details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->